### PR TITLE
Make the response channel larger than one and tweakable.

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -13,6 +13,8 @@ import (
 	gc "launchpad.net/gocheck"
 )
 
+var HookChannelSize = 10
+
 // HookCommandOutput intercepts CommandOutput to a function that passes the
 // actual command and it's output back via a channel, and returns the error
 // passed into this function.  It also returns a cleanup function so you can
@@ -20,7 +22,7 @@ import (
 func HookCommandOutput(
 	outputFunc *func(cmd *exec.Cmd) ([]byte, error), output []byte, err error) (<-chan *exec.Cmd, func()) {
 
-	cmdChan := make(chan *exec.Cmd, 1)
+	cmdChan := make(chan *exec.Cmd, HookChannelSize)
 	origCommandOutput := *outputFunc
 	cleanup := func() {
 		close(cmdChan)


### PR DESCRIPTION
Sometimes if the command is called more than once before the test has the ability to pull the command off the response channel, the test blocks as there is only once space on the channel.

By having a package level variable, this can be patched in the test to change the size.
