### PR TITLE
Skip stdlib depdencies during find imports

### DIFF
--- a/imports.go
+++ b/imports.go
@@ -12,7 +12,7 @@ import (
 
 // stdlib repesents the packages that belong to the standard library.
 var stdlib = map[string]bool{
-	"C":                   true, // not really a package, but has not dependencies
+	"C":                   true, // not really a package
 	"archive/tar":         true,
 	"archive/zip":         true,
 	"bufio":               true,


### PR DESCRIPTION
The find imports tests always exclude paths that don't begin with the stated prefix, so in truth they also implicitly exclude the std lib.

However, prior to this test the stdlib was being traversed to build up a dependency set, then discarded, which was fine. However this assumed that the location of the stdlib source was set, ie $GOROOT/src/pkg points to the source of the std library. However this is not required to be true, and is not true for gccgo.

To make this helper work across all compilers, establish a map of known standard library packages and don't recurse through them as it is not possible for the dependency graph to flow from a package in $GOROOT to $GOPATH, ie, the std lib cannot depend on a third party package.
