### PR TITLE
Include FakeHomeSuite.

### DIFF
--- a/home.go
+++ b/home.go
@@ -1,0 +1,113 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/juju/utils"
+	gc "launchpad.net/gocheck"
+)
+
+type TestFile struct {
+	Name, Data string
+}
+
+// FakeHome stores information about the user's home
+// environment so it can be cast aside for tests and
+// restored afterwards.
+type FakeHome struct {
+	files []TestFile
+}
+
+func MakeFakeHome(c *gc.C) *FakeHome {
+	fakeHome := c.MkDir()
+	utils.SetHome(fakeHome)
+
+	sshPath := filepath.Join(fakeHome, ".ssh")
+	err := os.Mkdir(sshPath, 0777)
+	c.Assert(err, gc.IsNil)
+	err = ioutil.WriteFile(filepath.Join(sshPath, "id_rsa.pub"), []byte("auth key\n"), 0666)
+	c.Assert(err, gc.IsNil)
+
+	return &FakeHome{
+		files: []TestFile{},
+	}
+}
+
+func (h *FakeHome) AddFiles(c *gc.C, files ...TestFile) {
+	for _, f := range files {
+		path := filepath.Join(utils.Home(), f.Name)
+		err := os.MkdirAll(filepath.Dir(path), 0700)
+		c.Assert(err, gc.IsNil)
+		err = ioutil.WriteFile(path, []byte(f.Data), 0666)
+		c.Assert(err, gc.IsNil)
+		h.files = append(h.files, f)
+	}
+}
+
+// FileContents returns the test file contents for the
+// given specified path (which may be relative, so
+// we compare with the base filename only).
+func (h *FakeHome) FileContents(c *gc.C, path string) string {
+	for _, f := range h.files {
+		if filepath.Base(f.Name) == filepath.Base(path) {
+			return f.Data
+		}
+	}
+	c.Fatalf("path attribute holds unknown test file: %q", path)
+	panic("unreachable")
+}
+
+// FileExists returns if the given relative file path exists
+// in the fake home.
+func (h *FakeHome) FileExists(path string) bool {
+	for _, f := range h.files {
+		if f.Name == path {
+			return true
+		}
+	}
+	return false
+}
+
+// HomePath joins the specified path snippets and returns
+// an absolute path under Juju home.
+func HomePath(names ...string) string {
+	all := append([]string{utils.Home()}, names...)
+	return filepath.Join(all...)
+}
+
+// FakeHomeSuite sets up a fake home directory before running tests.
+type FakeHomeSuite struct {
+	CleanupSuite
+	LoggingSuite
+	Home *FakeHome
+}
+
+func (s *FakeHomeSuite) SetUpSuite(c *gc.C) {
+	s.CleanupSuite.SetUpSuite(c)
+	s.LoggingSuite.SetUpSuite(c)
+}
+
+func (s *FakeHomeSuite) TearDownSuite(c *gc.C) {
+	s.LoggingSuite.TearDownSuite(c)
+	s.CleanupSuite.TearDownSuite(c)
+}
+
+func (s *FakeHomeSuite) SetUpTest(c *gc.C) {
+	s.CleanupSuite.SetUpTest(c)
+	s.LoggingSuite.SetUpTest(c)
+	home := utils.Home()
+	s.Home = MakeFakeHome(c)
+	s.AddCleanup(func(*gc.C) {
+		utils.SetHome(home)
+	})
+}
+
+func (s *FakeHomeSuite) TearDownTest(c *gc.C) {
+	s.LoggingSuite.TearDownTest(c)
+	s.CleanupSuite.TearDownTest(c)
+}

--- a/home_test.go
+++ b/home_test.go
@@ -1,0 +1,90 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package testing_test
+
+import (
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/juju/utils"
+	gc "launchpad.net/gocheck"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+)
+
+type fakeHomeSuite struct {
+	testing.IsolationSuite
+	fakeHomeSuite testing.FakeHomeSuite
+}
+
+var _ = gc.Suite(&fakeHomeSuite{})
+
+func (s *fakeHomeSuite) SetUpSuite(c *gc.C) {
+	s.IsolationSuite.SetUpSuite(c)
+	s.fakeHomeSuite = testing.FakeHomeSuite{}
+}
+
+func (s *fakeHomeSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	utils.SetHome("/tmp/tests")
+}
+
+func (s *fakeHomeSuite) TestHomeCreated(c *gc.C) {
+	// A fake home is created and set.
+	s.fakeHomeSuite.SetUpTest(c)
+	home := utils.Home()
+	c.Assert(home, gc.Not(gc.Equals), "/tmp/tests")
+	c.Assert(home, jc.IsDirectory)
+	s.fakeHomeSuite.TearDownTest(c)
+	// The original home has been restored.
+	c.Assert(utils.Home(), gc.Equals, "/tmp/tests")
+}
+
+func (s *fakeHomeSuite) TestSshDirSetUp(c *gc.C) {
+	// The SSH directory is properly created and set up.
+	s.fakeHomeSuite.SetUpTest(c)
+	sshDir := testing.HomePath(".ssh")
+	c.Assert(sshDir, jc.IsDirectory)
+	keyFile := filepath.Join(sshDir, "id_rsa.pub")
+	c.Assert(keyFile, jc.IsNonEmptyFile)
+	s.fakeHomeSuite.TearDownTest(c)
+}
+
+type makeFakeHomeSuite struct {
+	testing.IsolationSuite
+	home *testing.FakeHome
+}
+
+var _ = gc.Suite(&makeFakeHomeSuite{})
+
+func (s *makeFakeHomeSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.home = testing.MakeFakeHome(c)
+	testFile := testing.TestFile{
+		Name: "testfile-name",
+		Data: "testfile-data",
+	}
+	s.home.AddFiles(c, testFile)
+}
+
+func (s *makeFakeHomeSuite) TestAddFiles(c *gc.C) {
+	// Files are correctly added to the fake home.
+	expectedPath := filepath.Join(utils.Home(), "testfile-name")
+	contents, err := ioutil.ReadFile(expectedPath)
+	c.Assert(err, gc.IsNil)
+	c.Assert(string(contents), gc.Equals, "testfile-data")
+}
+
+func (s *makeFakeHomeSuite) TestFileContents(c *gc.C) {
+	// Files contents are returned as strings.
+	contents := s.home.FileContents(c, "testfile-name")
+	c.Assert(contents, gc.Equals, "testfile-data")
+}
+
+func (s *makeFakeHomeSuite) TestFileExists(c *gc.C) {
+	// It is possible to check whether a file exists in the fake home.
+	c.Assert(s.home.FileExists("testfile-name"), jc.IsTrue)
+	c.Assert(s.home.FileExists("no-such-file"), jc.IsFalse)
+}


### PR DESCRIPTION
Most of the home.go file is just copied from juju.
The FakeHomeSuite is now based on the Logging and Cleanup suites.
Improve FakeHomeSuite so that the original HOME is restored
on tear down.
Add the tests for the suite and the relevant helper functions.
