### PR TITLE
Preserve path in test environment

### DIFF
--- a/osenv.go
+++ b/osenv.go
@@ -23,6 +23,7 @@ func (s *OsEnvSuite) SetUpSuite(c *gc.C) {
 		s.oldEnvironment[parts[0]] = parts[1]
 	}
 	os.Clearenv()
+	os.Setenv("PATH", s.oldEnvironment["PATH"])
 }
 
 func (s *OsEnvSuite) TearDownSuite(c *gc.C) {
@@ -34,6 +35,7 @@ func (s *OsEnvSuite) TearDownSuite(c *gc.C) {
 
 func (s *OsEnvSuite) SetUpTest(c *gc.C) {
 	os.Clearenv()
+	os.Setenv("PATH", s.oldEnvironment["PATH"])
 }
 
 func (s *OsEnvSuite) TearDownTest(c *gc.C) {

--- a/osenv_test.go
+++ b/osenv_test.go
@@ -43,3 +43,17 @@ func (s *osEnvSuite) TestTestingEnvironment(c *gc.C) {
 	s.osEnvSuite.TearDownSuite(c)
 	c.Assert(os.Getenv("TESTING_OSENV_NEW"), gc.Equals, "")
 }
+
+func getPath() string {
+	return os.Getenv("PATH")
+}
+
+func (s *osEnvSuite) TestPathKeptInTestingEnvironment(c *gc.C) {
+	// osenv calls os.Clearenv but some tests need PATH to call binaries. Make
+	// sure PATH is preserved for those tests.
+	path := getPath()
+	s.osEnvSuite.SetUpSuite(c)
+	c.Assert(getPath(), gc.Equals, path)
+	s.osEnvSuite.SetUpTest(c)
+	c.Assert(getPath(), gc.Equals, path)
+}


### PR DESCRIPTION
Some tests -- notably juju/juju/upstart/upstart_test.go want to call
binaries like `rm` and `ln`. If we clear the env entirely they fail.

This preserves PATH in the OSEnvSuite and adds a test to ensure its
preservation.