### PR TITLE
Add test for suite level patch restoration.

### DIFF
--- a/cleanup.go
+++ b/cleanup.go
@@ -4,9 +4,9 @@
 package testing
 
 import (
-  "os/exec"
+	"os/exec"
 
-  gc "launchpad.net/gocheck"
+	gc "launchpad.net/gocheck"
 )
 
 type CleanupFunc func(*gc.C)
@@ -16,69 +16,69 @@ type cleanupStack []CleanupFunc
 // during either test tear down or suite tear down depending on the method
 // called.
 type CleanupSuite struct {
-  testStack  cleanupStack
-  suiteStack cleanupStack
-  setupSuite bool
+	testStack  cleanupStack
+	suiteStack cleanupStack
+	setupSuite bool
 }
 
 func (s *CleanupSuite) SetUpSuite(c *gc.C) {
-  s.suiteStack = nil
-  s.setupSuite = true
+	s.suiteStack = nil
+	s.setupSuite = true
 }
 
 func (s *CleanupSuite) TearDownSuite(c *gc.C) {
-  s.callStack(c, s.suiteStack)
-  s.setupSuite = false
+	s.callStack(c, s.suiteStack)
+	s.setupSuite = false
 }
 
 func (s *CleanupSuite) SetUpTest(c *gc.C) {
-  s.setupSuite = false
-  s.testStack = nil
+	s.setupSuite = false
+	s.testStack = nil
 }
 
 func (s *CleanupSuite) TearDownTest(c *gc.C) {
-  s.callStack(c, s.testStack)
+	s.callStack(c, s.testStack)
 }
 
 func (s *CleanupSuite) callStack(c *gc.C, stack cleanupStack) {
-  for i := len(stack) - 1; i >= 0; i-- {
-    stack[i](c)
-  }
+	for i := len(stack) - 1; i >= 0; i-- {
+		stack[i](c)
+	}
 }
 
 // AddCleanup pushes the cleanup function onto the stack of functions to be
 // called during TearDownTest.
 func (s *CleanupSuite) AddCleanup(cleanup CleanupFunc) {
-  s.testStack = append(s.testStack, cleanup)
+	s.testStack = append(s.testStack, cleanup)
 }
 
 // AddSuiteCleanup pushes the cleanup function onto the stack of functions to
 // be called during TearDownSuite.
 func (s *CleanupSuite) AddSuiteCleanup(cleanup CleanupFunc) {
-  s.suiteStack = append(s.suiteStack, cleanup)
+	s.suiteStack = append(s.suiteStack, cleanup)
 }
 
 // PatchEnvironment sets the environment variable 'name' the the value passed
 // in. The old value is saved and returned to the original value at test tear
 // down time using a cleanup function.
 func (s *CleanupSuite) PatchEnvironment(name, value string) {
-  restore := PatchEnvironment(name, value)
-  if s.setupSuite {
-    s.AddSuiteCleanup(func(*gc.C) { restore() })
-  } else {
-    s.AddCleanup(func(*gc.C) { restore() })
-  }
+	restore := PatchEnvironment(name, value)
+	if s.setupSuite {
+		s.AddSuiteCleanup(func(*gc.C) { restore() })
+	} else {
+		s.AddCleanup(func(*gc.C) { restore() })
+	}
 }
 
 // PatchEnvPathPrepend prepends the given path to the environment $PATH and restores the
 // original path on test teardown.
 func (s *CleanupSuite) PatchEnvPathPrepend(dir string) {
-  restore := PatchEnvPathPrepend(dir)
-  if s.setupSuite {
-    s.AddSuiteCleanup(func(*gc.C) { restore() })
-  } else {
-    s.AddCleanup(func(*gc.C) { restore() })
-  }
+	restore := PatchEnvPathPrepend(dir)
+	if s.setupSuite {
+		s.AddSuiteCleanup(func(*gc.C) { restore() })
+	} else {
+		s.AddCleanup(func(*gc.C) { restore() })
+	}
 }
 
 // PatchValue sets the 'dest' variable the the value passed in. The old value
@@ -86,23 +86,23 @@ func (s *CleanupSuite) PatchEnvPathPrepend(dir string) {
 // cleanup function. The value must be assignable to the element type of the
 // destination.
 func (s *CleanupSuite) PatchValue(dest, value interface{}) {
-  restore := PatchValue(dest, value)
-  if s.setupSuite {
-    s.AddSuiteCleanup(func(*gc.C) { restore() })
-  } else {
-    s.AddCleanup(func(*gc.C) { restore() })
-  }
+	restore := PatchValue(dest, value)
+	if s.setupSuite {
+		s.AddSuiteCleanup(func(*gc.C) { restore() })
+	} else {
+		s.AddCleanup(func(*gc.C) { restore() })
+	}
 }
 
 // HookCommandOutput calls the package function of the same name to mock out
 // the result of a particular comand execution, and will call the restore
 // function on test teardown.
 func (s *CleanupSuite) HookCommandOutput(
-  outputFunc *func(cmd *exec.Cmd) ([]byte, error),
-  output []byte,
-  err error,
+	outputFunc *func(cmd *exec.Cmd) ([]byte, error),
+	output []byte,
+	err error,
 ) <-chan *exec.Cmd {
-  result, restore := HookCommandOutput(outputFunc, output, err)
-  s.AddCleanup(func(*gc.C) { restore() })
-  return result
+	result, restore := HookCommandOutput(outputFunc, output, err)
+	s.AddCleanup(func(*gc.C) { restore() })
+	return result
 }

--- a/cleanup.go
+++ b/cleanup.go
@@ -4,9 +4,9 @@
 package testing
 
 import (
-	"os/exec"
+  "os/exec"
 
-	gc "launchpad.net/gocheck"
+  gc "launchpad.net/gocheck"
 )
 
 type CleanupFunc func(*gc.C)
@@ -16,57 +16,69 @@ type cleanupStack []CleanupFunc
 // during either test tear down or suite tear down depending on the method
 // called.
 type CleanupSuite struct {
-	testStack  cleanupStack
-	suiteStack cleanupStack
+  testStack  cleanupStack
+  suiteStack cleanupStack
+  setupSuite bool
 }
 
 func (s *CleanupSuite) SetUpSuite(c *gc.C) {
-	s.suiteStack = nil
+  s.suiteStack = nil
+  s.setupSuite = true
 }
 
 func (s *CleanupSuite) TearDownSuite(c *gc.C) {
-	s.callStack(c, s.suiteStack)
+  s.callStack(c, s.suiteStack)
+  s.setupSuite = false
 }
 
 func (s *CleanupSuite) SetUpTest(c *gc.C) {
-	s.testStack = nil
+  s.setupSuite = false
+  s.testStack = nil
 }
 
 func (s *CleanupSuite) TearDownTest(c *gc.C) {
-	s.callStack(c, s.testStack)
+  s.callStack(c, s.testStack)
 }
 
 func (s *CleanupSuite) callStack(c *gc.C, stack cleanupStack) {
-	for i := len(stack) - 1; i >= 0; i-- {
-		stack[i](c)
-	}
+  for i := len(stack) - 1; i >= 0; i-- {
+    stack[i](c)
+  }
 }
 
 // AddCleanup pushes the cleanup function onto the stack of functions to be
 // called during TearDownTest.
 func (s *CleanupSuite) AddCleanup(cleanup CleanupFunc) {
-	s.testStack = append(s.testStack, cleanup)
+  s.testStack = append(s.testStack, cleanup)
 }
 
 // AddSuiteCleanup pushes the cleanup function onto the stack of functions to
 // be called during TearDownSuite.
 func (s *CleanupSuite) AddSuiteCleanup(cleanup CleanupFunc) {
-	s.suiteStack = append(s.suiteStack, cleanup)
+  s.suiteStack = append(s.suiteStack, cleanup)
 }
 
 // PatchEnvironment sets the environment variable 'name' the the value passed
 // in. The old value is saved and returned to the original value at test tear
 // down time using a cleanup function.
 func (s *CleanupSuite) PatchEnvironment(name, value string) {
-	restore := PatchEnvironment(name, value)
-	s.AddCleanup(func(*gc.C) { restore() })
+  restore := PatchEnvironment(name, value)
+  if s.setupSuite {
+    s.AddSuiteCleanup(func(*gc.C) { restore() })
+  } else {
+    s.AddCleanup(func(*gc.C) { restore() })
+  }
 }
 
 // PatchEnvPathPrepend prepends the given path to the environment $PATH and restores the
 // original path on test teardown.
 func (s *CleanupSuite) PatchEnvPathPrepend(dir string) {
-	restore := PatchEnvPathPrepend(dir)
-	s.AddCleanup(func(*gc.C) { restore() })
+  restore := PatchEnvPathPrepend(dir)
+  if s.setupSuite {
+    s.AddSuiteCleanup(func(*gc.C) { restore() })
+  } else {
+    s.AddCleanup(func(*gc.C) { restore() })
+  }
 }
 
 // PatchValue sets the 'dest' variable the the value passed in. The old value
@@ -74,19 +86,23 @@ func (s *CleanupSuite) PatchEnvPathPrepend(dir string) {
 // cleanup function. The value must be assignable to the element type of the
 // destination.
 func (s *CleanupSuite) PatchValue(dest, value interface{}) {
-	restore := PatchValue(dest, value)
-	s.AddCleanup(func(*gc.C) { restore() })
+  restore := PatchValue(dest, value)
+  if s.setupSuite {
+    s.AddSuiteCleanup(func(*gc.C) { restore() })
+  } else {
+    s.AddCleanup(func(*gc.C) { restore() })
+  }
 }
 
 // HookCommandOutput calls the package function of the same name to mock out
 // the result of a particular comand execution, and will call the restore
 // function on test teardown.
 func (s *CleanupSuite) HookCommandOutput(
-	outputFunc *func(cmd *exec.Cmd) ([]byte, error),
-	output []byte,
-	err error,
+  outputFunc *func(cmd *exec.Cmd) ([]byte, error),
+  output []byte,
+  err error,
 ) <-chan *exec.Cmd {
-	result, restore := HookCommandOutput(outputFunc, output, err)
-	s.AddCleanup(func(*gc.C) { restore() })
-	return result
+  result, restore := HookCommandOutput(outputFunc, output, err)
+  s.AddCleanup(func(*gc.C) { restore() })
+  return result
 }

--- a/cleanup.go
+++ b/cleanup.go
@@ -4,9 +4,9 @@
 package testing
 
 import (
-  "os/exec"
+	"os/exec"
 
-  gc "launchpad.net/gocheck"
+	gc "launchpad.net/gocheck"
 )
 
 type CleanupFunc func(*gc.C)
@@ -16,58 +16,58 @@ type cleanupStack []CleanupFunc
 // during either test tear down or suite tear down depending on the method
 // called.
 type CleanupSuite struct {
-  testStack  cleanupStack
-  suiteStack cleanupStack
-  setUpTest  bool
+	testStack  cleanupStack
+	suiteStack cleanupStack
+	setUpTest  bool
 }
 
 func (s *CleanupSuite) SetUpSuite(c *gc.C) {
-  s.suiteStack = nil
+	s.suiteStack = nil
 }
 
 func (s *CleanupSuite) TearDownSuite(c *gc.C) {
-  s.callStack(c, s.suiteStack)
+	s.callStack(c, s.suiteStack)
 }
 
 func (s *CleanupSuite) SetUpTest(c *gc.C) {
-  s.setUpTest = true
-  s.testStack = nil
+	s.setUpTest = true
+	s.testStack = nil
 }
 
 func (s *CleanupSuite) TearDownTest(c *gc.C) {
-  s.callStack(c, s.testStack)
-  s.setUpTest = false
+	s.callStack(c, s.testStack)
+	s.setUpTest = false
 }
 
 func (s *CleanupSuite) callStack(c *gc.C, stack cleanupStack) {
-  for i := len(stack) - 1; i >= 0; i-- {
-    stack[i](c)
-  }
+	for i := len(stack) - 1; i >= 0; i-- {
+		stack[i](c)
+	}
 }
 
 // AddCleanup pushes the cleanup function onto the stack of functions to be
 // called during TearDownTest.
 func (s *CleanupSuite) AddCleanup(cleanup CleanupFunc) {
-  if s.setUpTest {
-    s.testStack = append(s.testStack, cleanup)
-  } else {
-    s.suiteStack = append(s.suiteStack, cleanup)
-  }
+	if s.setUpTest {
+		s.testStack = append(s.testStack, cleanup)
+	} else {
+		s.suiteStack = append(s.suiteStack, cleanup)
+	}
 }
 
 // PatchEnvironment sets the environment variable 'name' the the value passed
 // in. The old value is saved and returned to the original value at test tear
 // down time using a cleanup function.
 func (s *CleanupSuite) PatchEnvironment(name, value string) {
-  restore := PatchEnvironment(name, value)
-  s.AddCleanup(func(*gc.C) { restore() })
+	restore := PatchEnvironment(name, value)
+	s.AddCleanup(func(*gc.C) { restore() })
 }
 
 // PatchEnvPathPrepend prepends the given path to the environment $PATH and restores the
 // original path on test teardown.
 func (s *CleanupSuite) PatchEnvPathPrepend(dir string) {
-  restore := PatchEnvPathPrepend(dir)
-  s.AddCleanup(func(*gc.C) { restore() })
+	restore := PatchEnvPathPrepend(dir)
+	s.AddCleanup(func(*gc.C) { restore() })
 }
 
 // PatchValue sets the 'dest' variable the the value passed in. The old value
@@ -75,19 +75,19 @@ func (s *CleanupSuite) PatchEnvPathPrepend(dir string) {
 // cleanup function. The value must be assignable to the element type of the
 // destination.
 func (s *CleanupSuite) PatchValue(dest, value interface{}) {
-  restore := PatchValue(dest, value)
-  s.AddCleanup(func(*gc.C) { restore() })
+	restore := PatchValue(dest, value)
+	s.AddCleanup(func(*gc.C) { restore() })
 }
 
 // HookCommandOutput calls the package function of the same name to mock out
 // the result of a particular comand execution, and will call the restore
 // function on test teardown.
 func (s *CleanupSuite) HookCommandOutput(
-  outputFunc *func(cmd *exec.Cmd) ([]byte, error),
-  output []byte,
-  err error,
+	outputFunc *func(cmd *exec.Cmd) ([]byte, error),
+	output []byte,
+	err error,
 ) <-chan *exec.Cmd {
-  result, restore := HookCommandOutput(outputFunc, output, err)
-  s.AddCleanup(func(*gc.C) { restore() })
-  return result
+	result, restore := HookCommandOutput(outputFunc, output, err)
+	s.AddCleanup(func(*gc.C) { restore() })
+	return result
 }

--- a/cleanup.go
+++ b/cleanup.go
@@ -4,9 +4,9 @@
 package testing
 
 import (
-	"os/exec"
+  "os/exec"
 
-	gc "launchpad.net/gocheck"
+  gc "launchpad.net/gocheck"
 )
 
 type CleanupFunc func(*gc.C)
@@ -16,64 +16,58 @@ type cleanupStack []CleanupFunc
 // during either test tear down or suite tear down depending on the method
 // called.
 type CleanupSuite struct {
-	testStack  cleanupStack
-	suiteStack cleanupStack
-	setUpTest  bool
+  testStack  cleanupStack
+  suiteStack cleanupStack
+  setUpTest  bool
 }
 
 func (s *CleanupSuite) SetUpSuite(c *gc.C) {
-	s.suiteStack = nil
+  s.suiteStack = nil
 }
 
 func (s *CleanupSuite) TearDownSuite(c *gc.C) {
-	s.callStack(c, s.suiteStack)
+  s.callStack(c, s.suiteStack)
 }
 
 func (s *CleanupSuite) SetUpTest(c *gc.C) {
-	s.setUpTest = true
-	s.testStack = nil
+  s.setUpTest = true
+  s.testStack = nil
 }
 
 func (s *CleanupSuite) TearDownTest(c *gc.C) {
-	s.callStack(c, s.testStack)
-	s.setUpTest = false
+  s.callStack(c, s.testStack)
+  s.setUpTest = false
 }
 
 func (s *CleanupSuite) callStack(c *gc.C, stack cleanupStack) {
-	for i := len(stack) - 1; i >= 0; i-- {
-		stack[i](c)
-	}
+  for i := len(stack) - 1; i >= 0; i-- {
+    stack[i](c)
+  }
 }
 
 // AddCleanup pushes the cleanup function onto the stack of functions to be
 // called during TearDownTest.
 func (s *CleanupSuite) AddCleanup(cleanup CleanupFunc) {
-	if s.setUpTest {
-		s.testStack = append(s.testStack, cleanup)
-	} else {
-		s.suiteStack = append(s.suiteStack, cleanup)
-	}
-}
-
-// AddSuiteCleanup pushes the cleanup function onto the stack of functions to
-// be called during TearDownSuite.
-func (s *CleanupSuite) AddSuiteCleanup(cleanup CleanupFunc) {
-	s.suiteStack = append(s.suiteStack, cleanup)
+  if s.setUpTest {
+    s.testStack = append(s.testStack, cleanup)
+  } else {
+    s.suiteStack = append(s.suiteStack, cleanup)
+  }
 }
 
 // PatchEnvironment sets the environment variable 'name' the the value passed
 // in. The old value is saved and returned to the original value at test tear
 // down time using a cleanup function.
 func (s *CleanupSuite) PatchEnvironment(name, value string) {
-	restore := PatchEnvironment(name, value)
-	s.AddCleanup(func(*gc.C) { restore() })
+  restore := PatchEnvironment(name, value)
+  s.AddCleanup(func(*gc.C) { restore() })
 }
 
 // PatchEnvPathPrepend prepends the given path to the environment $PATH and restores the
 // original path on test teardown.
 func (s *CleanupSuite) PatchEnvPathPrepend(dir string) {
-	restore := PatchEnvPathPrepend(dir)
-	s.AddCleanup(func(*gc.C) { restore() })
+  restore := PatchEnvPathPrepend(dir)
+  s.AddCleanup(func(*gc.C) { restore() })
 }
 
 // PatchValue sets the 'dest' variable the the value passed in. The old value
@@ -81,19 +75,19 @@ func (s *CleanupSuite) PatchEnvPathPrepend(dir string) {
 // cleanup function. The value must be assignable to the element type of the
 // destination.
 func (s *CleanupSuite) PatchValue(dest, value interface{}) {
-	restore := PatchValue(dest, value)
-	s.AddCleanup(func(*gc.C) { restore() })
+  restore := PatchValue(dest, value)
+  s.AddCleanup(func(*gc.C) { restore() })
 }
 
 // HookCommandOutput calls the package function of the same name to mock out
 // the result of a particular comand execution, and will call the restore
 // function on test teardown.
 func (s *CleanupSuite) HookCommandOutput(
-	outputFunc *func(cmd *exec.Cmd) ([]byte, error),
-	output []byte,
-	err error,
+  outputFunc *func(cmd *exec.Cmd) ([]byte, error),
+  output []byte,
+  err error,
 ) <-chan *exec.Cmd {
-	result, restore := HookCommandOutput(outputFunc, output, err)
-	s.AddCleanup(func(*gc.C) { restore() })
-	return result
+  result, restore := HookCommandOutput(outputFunc, output, err)
+  s.AddCleanup(func(*gc.C) { restore() })
+  return result
 }

--- a/cleanup_test.go
+++ b/cleanup_test.go
@@ -29,6 +29,20 @@ func (s *cleanupSuite) TestTearDownTestEmpty(c *gc.C) {
 	s.SetUpTest(c)
 }
 
+func (s *cleanupSuite) TestTearDownTestWithSuiteSetup(c *gc.C) {
+	expSuiteVal := 42
+	expTestVal := 84
+	dest := 0
+	s.SetUpSuite(c)
+	s.PatchValue(&dest, expSuiteVal)
+	c.Assert(dest, gc.Equals, expSuiteVal)
+	s.SetUpTest(c)
+	s.PatchValue(&dest, expTestVal)
+	c.Assert(dest, gc.Equals, expTestVal)
+	s.TearDownTest(c)
+	c.Assert(dest, gc.Equals, expSuiteVal)
+}
+
 func (s *cleanupSuite) TestAddSuiteCleanup(c *gc.C) {
 	order := []string{}
 	s.AddSuiteCleanup(func(*gc.C) {

--- a/cleanup_test.go
+++ b/cleanup_test.go
@@ -4,129 +4,129 @@
 package testing_test
 
 import (
-  "os"
+	"os"
 
-  gc "launchpad.net/gocheck"
+	gc "launchpad.net/gocheck"
 
-  "github.com/juju/testing"
+	"github.com/juju/testing"
 )
 
 type cleanupSuite struct {
-  testing.CleanupSuite
+	testing.CleanupSuite
 }
 
 var _ = gc.Suite(&cleanupSuite{})
 
 func (s *cleanupSuite) TestTearDownSuiteEmpty(c *gc.C) {
-  suite := testing.CleanupSuite{}
-  suite.TearDownSuite(c)
-  suite.SetUpSuite(c)
+	suite := testing.CleanupSuite{}
+	suite.TearDownSuite(c)
+	suite.SetUpSuite(c)
 }
 
 func (s *cleanupSuite) TestTearDownTestEmpty(c *gc.C) {
-  suite := testing.CleanupSuite{}
-  suite.TearDownTest(c)
-  suite.SetUpTest(c)
+	suite := testing.CleanupSuite{}
+	suite.TearDownTest(c)
+	suite.SetUpTest(c)
 }
 
 func (s *cleanupSuite) TestTearDownTestWithPatch(c *gc.C) {
-  expSuiteVal := 42
-  expTestVal := 84
-  dest := 0
-  suite := testing.CleanupSuite{}
-  suite.SetUpSuite(c)
-  suite.PatchValue(&dest, expSuiteVal)
-  c.Assert(dest, gc.Equals, expSuiteVal)
-  suite.SetUpTest(c)
-  suite.PatchValue(&dest, expTestVal)
-  c.Assert(dest, gc.Equals, expTestVal)
-  suite.TearDownTest(c)
-  suite.SetUpTest(c)
-  c.Assert(dest, gc.Equals, expSuiteVal)
-  suite.TearDownTest(c)
+	expSuiteVal := 42
+	expTestVal := 84
+	dest := 0
+	suite := testing.CleanupSuite{}
+	suite.SetUpSuite(c)
+	suite.PatchValue(&dest, expSuiteVal)
+	c.Assert(dest, gc.Equals, expSuiteVal)
+	suite.SetUpTest(c)
+	suite.PatchValue(&dest, expTestVal)
+	c.Assert(dest, gc.Equals, expTestVal)
+	suite.TearDownTest(c)
+	suite.SetUpTest(c)
+	c.Assert(dest, gc.Equals, expSuiteVal)
+	suite.TearDownTest(c)
 }
 
 func (s *cleanupSuite) TestTearDownSuiteWithPatch(c *gc.C) {
-  expSuiteVal := 42
-  dest := 0
-  suite := testing.CleanupSuite{}
-  suite.SetUpSuite(c)
-  suite.PatchValue(&dest, expSuiteVal)
-  c.Assert(dest, gc.Equals, expSuiteVal)
-  suite.TearDownSuite(c)
-  c.Assert(dest, gc.Equals, 0)
+	expSuiteVal := 42
+	dest := 0
+	suite := testing.CleanupSuite{}
+	suite.SetUpSuite(c)
+	suite.PatchValue(&dest, expSuiteVal)
+	c.Assert(dest, gc.Equals, expSuiteVal)
+	suite.TearDownSuite(c)
+	c.Assert(dest, gc.Equals, 0)
 }
 
 func (s *cleanupSuite) TestAddSuiteCleanup(c *gc.C) {
-  suite := testing.CleanupSuite{}
-  order := []string{}
-  suite.AddCleanup(func(*gc.C) {
-    order = append(order, "first")
-  })
-  suite.AddCleanup(func(*gc.C) {
-    order = append(order, "second")
-  })
+	suite := testing.CleanupSuite{}
+	order := []string{}
+	suite.AddCleanup(func(*gc.C) {
+		order = append(order, "first")
+	})
+	suite.AddCleanup(func(*gc.C) {
+		order = append(order, "second")
+	})
 
-  suite.TearDownSuite(c)
-  c.Assert(order, gc.DeepEquals, []string{"second", "first"})
+	suite.TearDownSuite(c)
+	c.Assert(order, gc.DeepEquals, []string{"second", "first"})
 }
 
 func (s *cleanupSuite) TestAddCleanup(c *gc.C) {
-  suite := testing.CleanupSuite{}
-  order := []string{}
-  goCheck := gc.C{}
-  suite.SetUpTest(&goCheck)
-  suite.AddCleanup(func(*gc.C) {
-    order = append(order, "first")
-  })
-  suite.AddCleanup(func(*gc.C) {
-    order = append(order, "second")
-  })
+	suite := testing.CleanupSuite{}
+	order := []string{}
+	goCheck := gc.C{}
+	suite.SetUpTest(&goCheck)
+	suite.AddCleanup(func(*gc.C) {
+		order = append(order, "first")
+	})
+	suite.AddCleanup(func(*gc.C) {
+		order = append(order, "second")
+	})
 
-  suite.TearDownTest(c)
-  c.Assert(order, gc.DeepEquals, []string{"second", "first"})
+	suite.TearDownTest(c)
+	c.Assert(order, gc.DeepEquals, []string{"second", "first"})
 }
 
 func (s *cleanupSuite) TestPatchEnvironment(c *gc.C) {
-  suite := testing.CleanupSuite{}
-  goCheck := gc.C{}
-  suite.SetUpTest(&goCheck)
-  const envName = "TESTING_PATCH_ENVIRONMENT"
-  os.Setenv(envName, "initial")
+	suite := testing.CleanupSuite{}
+	goCheck := gc.C{}
+	suite.SetUpTest(&goCheck)
+	const envName = "TESTING_PATCH_ENVIRONMENT"
+	os.Setenv(envName, "initial")
 
-  suite.PatchEnvironment(envName, "new value")
-  // Using check to make sure the environment gets set back properly in the test.
-  c.Check(os.Getenv(envName), gc.Equals, "new value")
+	suite.PatchEnvironment(envName, "new value")
+	// Using check to make sure the environment gets set back properly in the test.
+	c.Check(os.Getenv(envName), gc.Equals, "new value")
 
-  suite.TearDownTest(&goCheck)
-  c.Check(os.Getenv(envName), gc.Equals, "initial")
+	suite.TearDownTest(&goCheck)
+	c.Check(os.Getenv(envName), gc.Equals, "initial")
 }
 
 func (s *cleanupSuite) TestPatchValueInt(c *gc.C) {
-  suite := testing.CleanupSuite{}
-  goCheck := gc.C{}
-  suite.SetUpTest(&goCheck)
-  i := 42
-  suite.PatchValue(&i, 0)
-  c.Assert(i, gc.Equals, 0)
+	suite := testing.CleanupSuite{}
+	goCheck := gc.C{}
+	suite.SetUpTest(&goCheck)
+	i := 42
+	suite.PatchValue(&i, 0)
+	c.Assert(i, gc.Equals, 0)
 
-  suite.TearDownTest(c)
-  c.Assert(i, gc.Equals, 42)
+	suite.TearDownTest(c)
+	c.Assert(i, gc.Equals, 42)
 }
 
 func (s *cleanupSuite) TestPatchValueFunction(c *gc.C) {
-  suite := testing.CleanupSuite{}
-  goCheck := gc.C{}
-  suite.SetUpTest(&goCheck)
-  function := func() string {
-    return "original"
-  }
+	suite := testing.CleanupSuite{}
+	goCheck := gc.C{}
+	suite.SetUpTest(&goCheck)
+	function := func() string {
+		return "original"
+	}
 
-  suite.PatchValue(&function, func() string {
-    return "patched"
-  })
-  c.Assert(function(), gc.Equals, "patched")
+	suite.PatchValue(&function, func() string {
+		return "patched"
+	})
+	c.Assert(function(), gc.Equals, "patched")
 
-  suite.TearDownTest(&goCheck)
-  c.Assert(function(), gc.Equals, "original")
+	suite.TearDownTest(&goCheck)
+	c.Assert(function(), gc.Equals, "original")
 }

--- a/cleanup_test.go
+++ b/cleanup_test.go
@@ -4,126 +4,131 @@
 package testing_test
 
 import (
-	"os"
+  "os"
 
-	gc "launchpad.net/gocheck"
+  gc "launchpad.net/gocheck"
 
-	"github.com/juju/testing"
+  "github.com/juju/testing"
 )
 
 type cleanupSuite struct {
-	testing.CleanupSuite
+  testing.CleanupSuite
 }
 
 var _ = gc.Suite(&cleanupSuite{})
 
 func (s *cleanupSuite) TestTearDownSuiteEmpty(c *gc.C) {
-	// The suite stack is empty initially, check we can tear that down.
-	s.TearDownSuite(c)
-	s.SetUpSuite(c)
+  // The suite stack is empty initially, check we can tear that down.
+  s.TearDownSuite(c)
+  s.SetUpSuite(c)
 }
 
 func (s *cleanupSuite) TestTearDownTestEmpty(c *gc.C) {
-	// The test stack is empty initially, check we can tear that down.
-	s.TearDownTest(c)
-	s.SetUpTest(c)
+  // The test stack is empty initially, check we can tear that down.
+  s.TearDownTest(c)
+  s.SetUpTest(c)
 }
 
 func (s *cleanupSuite) TestTearDownTestWithSuiteSetup(c *gc.C) {
-	expSuiteVal := 42
-	expTestVal := 84
-	dest := 0
-	s.SetUpSuite(c)
-	s.PatchValue(&dest, expSuiteVal)
-	c.Assert(dest, gc.Equals, expSuiteVal)
-	s.SetUpTest(c)
-	s.PatchValue(&dest, expTestVal)
-	c.Assert(dest, gc.Equals, expTestVal)
-	s.TearDownTest(c)
-	c.Assert(dest, gc.Equals, expSuiteVal)
+  expSuiteVal := 42
+  expTestVal := 84
+  dest := 0
+  suite := cleanupSuite{}
+  suite.SetUpSuite(c)
+  suite.PatchValue(&dest, expSuiteVal)
+  c.Assert(dest, gc.Equals, expSuiteVal)
+  suite.SetUpTest(c)
+  suite.PatchValue(&dest, expTestVal)
+  c.Assert(dest, gc.Equals, expTestVal)
+  suite.TearDownTest(c)
+  suite.SetUpTest(c)
+  c.Assert(dest, gc.Equals, expSuiteVal)
+  suite.TearDownTest(c)
+  suite.TearDownSuite(c)
+  c.Assert(dest, gc.Equals, 0)
 }
 
 func (s *cleanupSuite) TestAddSuiteCleanup(c *gc.C) {
-	order := []string{}
-	s.AddSuiteCleanup(func(*gc.C) {
-		order = append(order, "first")
-	})
-	s.AddSuiteCleanup(func(*gc.C) {
-		order = append(order, "second")
-	})
+  order := []string{}
+  s.AddSuiteCleanup(func(*gc.C) {
+    order = append(order, "first")
+  })
+  s.AddSuiteCleanup(func(*gc.C) {
+    order = append(order, "second")
+  })
 
-	s.TearDownSuite(c)
-	c.Assert(order, gc.DeepEquals, []string{"second", "first"})
+  s.TearDownSuite(c)
+  c.Assert(order, gc.DeepEquals, []string{"second", "first"})
 
-	// SetUpSuite resets the cleanup stack, this stops the cleanup functions
-	// being called again.
-	s.SetUpSuite(c)
+  // SetUpSuite resets the cleanup stack, this stops the cleanup functions
+  // being called again.
+  s.SetUpSuite(c)
 }
 
 func (s *cleanupSuite) TestAddCleanup(c *gc.C) {
-	order := []string{}
-	s.AddCleanup(func(*gc.C) {
-		order = append(order, "first")
-	})
-	s.AddCleanup(func(*gc.C) {
-		order = append(order, "second")
-	})
+  order := []string{}
+  s.AddCleanup(func(*gc.C) {
+    order = append(order, "first")
+  })
+  s.AddCleanup(func(*gc.C) {
+    order = append(order, "second")
+  })
 
-	s.TearDownTest(c)
-	c.Assert(order, gc.DeepEquals, []string{"second", "first"})
+  s.TearDownTest(c)
+  c.Assert(order, gc.DeepEquals, []string{"second", "first"})
 
-	// SetUpTest resets the cleanup stack, this stops the cleanup functions
-	// being called again.
-	s.SetUpTest(c)
+  // SetUpTest resets the cleanup stack, this stops the cleanup functions
+  // being called again.
+  s.SetUpTest(c)
 }
 
 func (s *cleanupSuite) TestPatchEnvironment(c *gc.C) {
-	const envName = "TESTING_PATCH_ENVIRONMENT"
-	// remember the old value, and set it to something we can check
-	oldValue := os.Getenv(envName)
-	os.Setenv(envName, "initial")
+  const envName = "TESTING_PATCH_ENVIRONMENT"
+  // remember the old value, and set it to something we can check
+  oldValue := os.Getenv(envName)
+  os.Setenv(envName, "initial")
 
-	s.PatchEnvironment(envName, "new value")
-	// Using check to make sure the environment gets set back properly in the test.
-	c.Check(os.Getenv(envName), gc.Equals, "new value")
+  s.PatchEnvironment(envName, "new value")
+  // Using check to make sure the environment gets set back properly in the test.
+  c.Check(os.Getenv(envName), gc.Equals, "new value")
 
-	s.TearDownTest(c)
-	c.Check(os.Getenv(envName), gc.Equals, "initial")
+  s.TearDownTest(c)
+  c.Check(os.Getenv(envName), gc.Equals, "initial")
 
-	// SetUpTest resets the cleanup stack, this stops the cleanup functions
-	// being called again.
-	s.SetUpTest(c)
-	// explicitly return the envName to the old value
-	os.Setenv(envName, oldValue)
+  // SetUpTest resets the cleanup stack, this stops the cleanup functions
+  // being called again.
+  s.SetUpTest(c)
+  // explicitly return the envName to the old value
+  os.Setenv(envName, oldValue)
 }
 
 func (s *cleanupSuite) TestPatchValueInt(c *gc.C) {
-	i := 42
-	s.PatchValue(&i, 0)
-	c.Assert(i, gc.Equals, 0)
+  i := 42
+  s.PatchValue(&i, 0)
+  c.Assert(i, gc.Equals, 0)
 
-	s.TearDownTest(c)
-	c.Assert(i, gc.Equals, 42)
+  s.TearDownTest(c)
+  c.Assert(i, gc.Equals, 42)
 
-	// SetUpTest resets the cleanup stack, this stops the cleanup functions
-	// being called again.
-	s.SetUpTest(c)
+  // SetUpTest resets the cleanup stack, this stops the cleanup functions
+  // being called again.
+  s.SetUpTest(c)
 }
 
 func (s *cleanupSuite) TestPatchValueFunction(c *gc.C) {
-	function := func() string {
-		return "original"
-	}
+  function := func() string {
+    return "original"
+  }
 
-	s.PatchValue(&function, func() string {
-		return "patched"
-	})
-	c.Assert(function(), gc.Equals, "patched")
+  s.PatchValue(&function, func() string {
+    return "patched"
+  })
+  c.Assert(function(), gc.Equals, "patched")
 
-	s.TearDownTest(c)
-	c.Assert(function(), gc.Equals, "original")
+  s.TearDownTest(c)
+  c.Assert(function(), gc.Equals, "original")
 
-	// SetUpTest resets the cleanup stack, this stops the cleanup functions
-	// being called again.
-	s.SetUpTest(c)
+  // SetUpTest resets the cleanup stack, this stops the cleanup functions
+  // being called again.
+  s.SetUpTest(c)
 }

--- a/cleanup_test.go
+++ b/cleanup_test.go
@@ -4,131 +4,131 @@
 package testing_test
 
 import (
-  "os"
+	"os"
 
-  gc "launchpad.net/gocheck"
+	gc "launchpad.net/gocheck"
 
-  "github.com/juju/testing"
+	"github.com/juju/testing"
 )
 
 type cleanupSuite struct {
-  testing.CleanupSuite
+	testing.CleanupSuite
 }
 
 var _ = gc.Suite(&cleanupSuite{})
 
 func (s *cleanupSuite) TestTearDownSuiteEmpty(c *gc.C) {
-  // The suite stack is empty initially, check we can tear that down.
-  s.TearDownSuite(c)
-  s.SetUpSuite(c)
+	// The suite stack is empty initially, check we can tear that down.
+	s.TearDownSuite(c)
+	s.SetUpSuite(c)
 }
 
 func (s *cleanupSuite) TestTearDownTestEmpty(c *gc.C) {
-  // The test stack is empty initially, check we can tear that down.
-  s.TearDownTest(c)
-  s.SetUpTest(c)
+	// The test stack is empty initially, check we can tear that down.
+	s.TearDownTest(c)
+	s.SetUpTest(c)
 }
 
 func (s *cleanupSuite) TestTearDownTestWithSuiteSetup(c *gc.C) {
-  expSuiteVal := 42
-  expTestVal := 84
-  dest := 0
-  suite := cleanupSuite{}
-  suite.SetUpSuite(c)
-  suite.PatchValue(&dest, expSuiteVal)
-  c.Assert(dest, gc.Equals, expSuiteVal)
-  suite.SetUpTest(c)
-  suite.PatchValue(&dest, expTestVal)
-  c.Assert(dest, gc.Equals, expTestVal)
-  suite.TearDownTest(c)
-  suite.SetUpTest(c)
-  c.Assert(dest, gc.Equals, expSuiteVal)
-  suite.TearDownTest(c)
-  suite.TearDownSuite(c)
-  c.Assert(dest, gc.Equals, 0)
+	expSuiteVal := 42
+	expTestVal := 84
+	dest := 0
+	suite := cleanupSuite{}
+	suite.SetUpSuite(c)
+	suite.PatchValue(&dest, expSuiteVal)
+	c.Assert(dest, gc.Equals, expSuiteVal)
+	suite.SetUpTest(c)
+	suite.PatchValue(&dest, expTestVal)
+	c.Assert(dest, gc.Equals, expTestVal)
+	suite.TearDownTest(c)
+	suite.SetUpTest(c)
+	c.Assert(dest, gc.Equals, expSuiteVal)
+	suite.TearDownTest(c)
+	suite.TearDownSuite(c)
+	c.Assert(dest, gc.Equals, 0)
 }
 
 func (s *cleanupSuite) TestAddSuiteCleanup(c *gc.C) {
-  order := []string{}
-  s.AddSuiteCleanup(func(*gc.C) {
-    order = append(order, "first")
-  })
-  s.AddSuiteCleanup(func(*gc.C) {
-    order = append(order, "second")
-  })
+	order := []string{}
+	s.AddSuiteCleanup(func(*gc.C) {
+		order = append(order, "first")
+	})
+	s.AddSuiteCleanup(func(*gc.C) {
+		order = append(order, "second")
+	})
 
-  s.TearDownSuite(c)
-  c.Assert(order, gc.DeepEquals, []string{"second", "first"})
+	s.TearDownSuite(c)
+	c.Assert(order, gc.DeepEquals, []string{"second", "first"})
 
-  // SetUpSuite resets the cleanup stack, this stops the cleanup functions
-  // being called again.
-  s.SetUpSuite(c)
+	// SetUpSuite resets the cleanup stack, this stops the cleanup functions
+	// being called again.
+	s.SetUpSuite(c)
 }
 
 func (s *cleanupSuite) TestAddCleanup(c *gc.C) {
-  order := []string{}
-  s.AddCleanup(func(*gc.C) {
-    order = append(order, "first")
-  })
-  s.AddCleanup(func(*gc.C) {
-    order = append(order, "second")
-  })
+	order := []string{}
+	s.AddCleanup(func(*gc.C) {
+		order = append(order, "first")
+	})
+	s.AddCleanup(func(*gc.C) {
+		order = append(order, "second")
+	})
 
-  s.TearDownTest(c)
-  c.Assert(order, gc.DeepEquals, []string{"second", "first"})
+	s.TearDownTest(c)
+	c.Assert(order, gc.DeepEquals, []string{"second", "first"})
 
-  // SetUpTest resets the cleanup stack, this stops the cleanup functions
-  // being called again.
-  s.SetUpTest(c)
+	// SetUpTest resets the cleanup stack, this stops the cleanup functions
+	// being called again.
+	s.SetUpTest(c)
 }
 
 func (s *cleanupSuite) TestPatchEnvironment(c *gc.C) {
-  const envName = "TESTING_PATCH_ENVIRONMENT"
-  // remember the old value, and set it to something we can check
-  oldValue := os.Getenv(envName)
-  os.Setenv(envName, "initial")
+	const envName = "TESTING_PATCH_ENVIRONMENT"
+	// remember the old value, and set it to something we can check
+	oldValue := os.Getenv(envName)
+	os.Setenv(envName, "initial")
 
-  s.PatchEnvironment(envName, "new value")
-  // Using check to make sure the environment gets set back properly in the test.
-  c.Check(os.Getenv(envName), gc.Equals, "new value")
+	s.PatchEnvironment(envName, "new value")
+	// Using check to make sure the environment gets set back properly in the test.
+	c.Check(os.Getenv(envName), gc.Equals, "new value")
 
-  s.TearDownTest(c)
-  c.Check(os.Getenv(envName), gc.Equals, "initial")
+	s.TearDownTest(c)
+	c.Check(os.Getenv(envName), gc.Equals, "initial")
 
-  // SetUpTest resets the cleanup stack, this stops the cleanup functions
-  // being called again.
-  s.SetUpTest(c)
-  // explicitly return the envName to the old value
-  os.Setenv(envName, oldValue)
+	// SetUpTest resets the cleanup stack, this stops the cleanup functions
+	// being called again.
+	s.SetUpTest(c)
+	// explicitly return the envName to the old value
+	os.Setenv(envName, oldValue)
 }
 
 func (s *cleanupSuite) TestPatchValueInt(c *gc.C) {
-  i := 42
-  s.PatchValue(&i, 0)
-  c.Assert(i, gc.Equals, 0)
+	i := 42
+	s.PatchValue(&i, 0)
+	c.Assert(i, gc.Equals, 0)
 
-  s.TearDownTest(c)
-  c.Assert(i, gc.Equals, 42)
+	s.TearDownTest(c)
+	c.Assert(i, gc.Equals, 42)
 
-  // SetUpTest resets the cleanup stack, this stops the cleanup functions
-  // being called again.
-  s.SetUpTest(c)
+	// SetUpTest resets the cleanup stack, this stops the cleanup functions
+	// being called again.
+	s.SetUpTest(c)
 }
 
 func (s *cleanupSuite) TestPatchValueFunction(c *gc.C) {
-  function := func() string {
-    return "original"
-  }
+	function := func() string {
+		return "original"
+	}
 
-  s.PatchValue(&function, func() string {
-    return "patched"
-  })
-  c.Assert(function(), gc.Equals, "patched")
+	s.PatchValue(&function, func() string {
+		return "patched"
+	})
+	c.Assert(function(), gc.Equals, "patched")
 
-  s.TearDownTest(c)
-  c.Assert(function(), gc.Equals, "original")
+	s.TearDownTest(c)
+	c.Assert(function(), gc.Equals, "original")
 
-  // SetUpTest resets the cleanup stack, this stops the cleanup functions
-  // being called again.
-  s.SetUpTest(c)
+	// SetUpTest resets the cleanup stack, this stops the cleanup functions
+	// being called again.
+	s.SetUpTest(c)
 }

--- a/cleanup_test.go
+++ b/cleanup_test.go
@@ -4,140 +4,129 @@
 package testing_test
 
 import (
-	"os"
+  "os"
 
-	gc "launchpad.net/gocheck"
+  gc "launchpad.net/gocheck"
 
-	"github.com/juju/testing"
+  "github.com/juju/testing"
 )
 
 type cleanupSuite struct {
-	testing.CleanupSuite
+  testing.CleanupSuite
 }
 
 var _ = gc.Suite(&cleanupSuite{})
 
 func (s *cleanupSuite) TestTearDownSuiteEmpty(c *gc.C) {
-	// The suite stack is empty initially, check we can tear that down.
-	s.TearDownSuite(c)
-	s.SetUpSuite(c)
+  suite := testing.CleanupSuite{}
+  suite.TearDownSuite(c)
+  suite.SetUpSuite(c)
 }
 
 func (s *cleanupSuite) TestTearDownTestEmpty(c *gc.C) {
-	// The test stack is empty initially, check we can tear that down.
-	s.TearDownTest(c)
-	s.SetUpTest(c)
+  suite := testing.CleanupSuite{}
+  suite.TearDownTest(c)
+  suite.SetUpTest(c)
 }
 
 func (s *cleanupSuite) TestTearDownTestWithPatch(c *gc.C) {
-	expSuiteVal := 42
-	expTestVal := 84
-	dest := 0
-	var suite testing.CleanupSuite
-	suite.SetUpSuite(c)
-	suite.PatchValue(&dest, expSuiteVal)
-	c.Assert(dest, gc.Equals, expSuiteVal)
-	suite.SetUpTest(c)
-	suite.PatchValue(&dest, expTestVal)
-	c.Assert(dest, gc.Equals, expTestVal)
-	suite.TearDownTest(c)
-	suite.SetUpTest(c)
-	c.Assert(dest, gc.Equals, expSuiteVal)
-	suite.TearDownTest(c)
+  expSuiteVal := 42
+  expTestVal := 84
+  dest := 0
+  suite := testing.CleanupSuite{}
+  suite.SetUpSuite(c)
+  suite.PatchValue(&dest, expSuiteVal)
+  c.Assert(dest, gc.Equals, expSuiteVal)
+  suite.SetUpTest(c)
+  suite.PatchValue(&dest, expTestVal)
+  c.Assert(dest, gc.Equals, expTestVal)
+  suite.TearDownTest(c)
+  suite.SetUpTest(c)
+  c.Assert(dest, gc.Equals, expSuiteVal)
+  suite.TearDownTest(c)
 }
 
 func (s *cleanupSuite) TestTearDownSuiteWithPatch(c *gc.C) {
-	expSuiteVal := 42
-	dest := 0
-	var suite testing.CleanupSuite
-	suite.SetUpSuite(c)
-	suite.PatchValue(&dest, expSuiteVal)
-	c.Assert(dest, gc.Equals, expSuiteVal)
-	suite.TearDownSuite(c)
-	c.Assert(dest, gc.Equals, 0)
+  expSuiteVal := 42
+  dest := 0
+  suite := testing.CleanupSuite{}
+  suite.SetUpSuite(c)
+  suite.PatchValue(&dest, expSuiteVal)
+  c.Assert(dest, gc.Equals, expSuiteVal)
+  suite.TearDownSuite(c)
+  c.Assert(dest, gc.Equals, 0)
 }
 
 func (s *cleanupSuite) TestAddSuiteCleanup(c *gc.C) {
-	order := []string{}
-	s.AddSuiteCleanup(func(*gc.C) {
-		order = append(order, "first")
-	})
-	s.AddSuiteCleanup(func(*gc.C) {
-		order = append(order, "second")
-	})
+  suite := testing.CleanupSuite{}
+  order := []string{}
+  suite.AddCleanup(func(*gc.C) {
+    order = append(order, "first")
+  })
+  suite.AddCleanup(func(*gc.C) {
+    order = append(order, "second")
+  })
 
-	s.TearDownSuite(c)
-	c.Assert(order, gc.DeepEquals, []string{"second", "first"})
-
-	// SetUpSuite resets the cleanup stack, this stops the cleanup functions
-	// being called again.
-	s.SetUpSuite(c)
+  suite.TearDownSuite(c)
+  c.Assert(order, gc.DeepEquals, []string{"second", "first"})
 }
 
 func (s *cleanupSuite) TestAddCleanup(c *gc.C) {
-	order := []string{}
-	s.AddCleanup(func(*gc.C) {
-		order = append(order, "first")
-	})
-	s.AddCleanup(func(*gc.C) {
-		order = append(order, "second")
-	})
+  suite := testing.CleanupSuite{}
+  order := []string{}
+  goCheck := gc.C{}
+  suite.SetUpTest(&goCheck)
+  suite.AddCleanup(func(*gc.C) {
+    order = append(order, "first")
+  })
+  suite.AddCleanup(func(*gc.C) {
+    order = append(order, "second")
+  })
 
-	s.TearDownTest(c)
-	c.Assert(order, gc.DeepEquals, []string{"second", "first"})
-
-	// SetUpTest resets the cleanup stack, this stops the cleanup functions
-	// being called again.
-	s.SetUpTest(c)
+  suite.TearDownTest(c)
+  c.Assert(order, gc.DeepEquals, []string{"second", "first"})
 }
 
 func (s *cleanupSuite) TestPatchEnvironment(c *gc.C) {
-	const envName = "TESTING_PATCH_ENVIRONMENT"
-	// remember the old value, and set it to something we can check
-	oldValue := os.Getenv(envName)
-	os.Setenv(envName, "initial")
+  suite := testing.CleanupSuite{}
+  goCheck := gc.C{}
+  suite.SetUpTest(&goCheck)
+  const envName = "TESTING_PATCH_ENVIRONMENT"
+  os.Setenv(envName, "initial")
 
-	s.PatchEnvironment(envName, "new value")
-	// Using check to make sure the environment gets set back properly in the test.
-	c.Check(os.Getenv(envName), gc.Equals, "new value")
+  suite.PatchEnvironment(envName, "new value")
+  // Using check to make sure the environment gets set back properly in the test.
+  c.Check(os.Getenv(envName), gc.Equals, "new value")
 
-	s.TearDownTest(c)
-	c.Check(os.Getenv(envName), gc.Equals, "initial")
-
-	// SetUpTest resets the cleanup stack, this stops the cleanup functions
-	// being called again.
-	s.SetUpTest(c)
-	// explicitly return the envName to the old value
-	os.Setenv(envName, oldValue)
+  suite.TearDownTest(&goCheck)
+  c.Check(os.Getenv(envName), gc.Equals, "initial")
 }
 
 func (s *cleanupSuite) TestPatchValueInt(c *gc.C) {
-	i := 42
-	s.PatchValue(&i, 0)
-	c.Assert(i, gc.Equals, 0)
+  suite := testing.CleanupSuite{}
+  goCheck := gc.C{}
+  suite.SetUpTest(&goCheck)
+  i := 42
+  suite.PatchValue(&i, 0)
+  c.Assert(i, gc.Equals, 0)
 
-	s.TearDownTest(c)
-	c.Assert(i, gc.Equals, 42)
-
-	// SetUpTest resets the cleanup stack, this stops the cleanup functions
-	// being called again.
-	s.SetUpTest(c)
+  suite.TearDownTest(c)
+  c.Assert(i, gc.Equals, 42)
 }
 
 func (s *cleanupSuite) TestPatchValueFunction(c *gc.C) {
-	function := func() string {
-		return "original"
-	}
+  suite := testing.CleanupSuite{}
+  goCheck := gc.C{}
+  suite.SetUpTest(&goCheck)
+  function := func() string {
+    return "original"
+  }
 
-	s.PatchValue(&function, func() string {
-		return "patched"
-	})
-	c.Assert(function(), gc.Equals, "patched")
+  suite.PatchValue(&function, func() string {
+    return "patched"
+  })
+  c.Assert(function(), gc.Equals, "patched")
 
-	s.TearDownTest(c)
-	c.Assert(function(), gc.Equals, "original")
-
-	// SetUpTest resets the cleanup stack, this stops the cleanup functions
-	// being called again.
-	s.SetUpTest(c)
+  suite.TearDownTest(&goCheck)
+  c.Assert(function(), gc.Equals, "original")
 }

--- a/cleanup_test.go
+++ b/cleanup_test.go
@@ -29,11 +29,11 @@ func (s *cleanupSuite) TestTearDownTestEmpty(c *gc.C) {
 	s.SetUpTest(c)
 }
 
-func (s *cleanupSuite) TestTearDownTestWithSuiteSetup(c *gc.C) {
+func (s *cleanupSuite) TestTearDownTestWithPatch(c *gc.C) {
 	expSuiteVal := 42
 	expTestVal := 84
 	dest := 0
-	suite := cleanupSuite{}
+	var suite testing.CleanupSuite
 	suite.SetUpSuite(c)
 	suite.PatchValue(&dest, expSuiteVal)
 	c.Assert(dest, gc.Equals, expSuiteVal)
@@ -44,6 +44,15 @@ func (s *cleanupSuite) TestTearDownTestWithSuiteSetup(c *gc.C) {
 	suite.SetUpTest(c)
 	c.Assert(dest, gc.Equals, expSuiteVal)
 	suite.TearDownTest(c)
+}
+
+func (s *cleanupSuite) TestTearDownSuiteWithPatch(c *gc.C) {
+	expSuiteVal := 42
+	dest := 0
+	var suite testing.CleanupSuite
+	suite.SetUpSuite(c)
+	suite.PatchValue(&dest, expSuiteVal)
+	c.Assert(dest, gc.Equals, expSuiteVal)
 	suite.TearDownSuite(c)
 	c.Assert(dest, gc.Equals, 0)
 }


### PR DESCRIPTION
Add test to check that when a test value is patched in
it's value is restored to the previous value on test
tear down.

https://bugs.launchpad.net/juju-core/+bug/1308101