### PR TITLE
maybe clearenv on windows

### DIFF
--- a/osenv.go
+++ b/osenv.go
@@ -5,6 +5,7 @@ package testing
 
 import (
 	"os"
+	"runtime"
 	"strings"
 
 	gc "launchpad.net/gocheck"
@@ -16,13 +17,79 @@ type OsEnvSuite struct {
 	oldEnvironment map[string]string
 }
 
+// windowsVariables is a whitelist of windows environment variables
+// that will be retained if found. Some of these variables are needed
+// by standard go packages (such as os.TempDir()), as well as powershell
+var windowsVariables = []string{
+	"ALLUSERSPROFILE",
+	"APPDATA",
+	"CommonProgramFiles",
+	"CommonProgramFiles(x86)",
+	"CommonProgramW6432",
+	"COMPUTERNAME",
+	"ComSpec",
+	"FP_NO_HOST_CHECK",
+	"HOMEDRIVE",
+	"HOMEPATH",
+	"LOCALAPPDATA",
+	"LOGONSERVER",
+	"NUMBER_OF_PROCESSORS",
+	"OS",
+	"Path",
+	"PATHEXT",
+	"PROCESSOR_ARCHITECTURE",
+	"PROCESSOR_IDENTIFIER",
+	"PROCESSOR_LEVEL",
+	"PROCESSOR_REVISION",
+	"ProgramData",
+	"ProgramFiles",
+	"ProgramFiles(x86)",
+	"ProgramW6432",
+	"PROMPT",
+	"PSModulePath",
+	"PUBLIC",
+	"SESSIONNAME",
+	"SystemDrive",
+	"SystemRoot",
+	"TEMP",
+	"TMP",
+	"USERDOMAIN",
+	"USERDOMAIN_ROAMINGPROFILE",
+	"USERNAME",
+	"USERPROFILE",
+	"windir",
+}
+
+func (s *OsEnvSuite) setEnviron() {
+	var envList []string
+	switch runtime.GOOS {
+	case "windows":
+		envList = windowsVariables
+	default:
+		envList = []string{}
+	}
+	for _, envVar := range envList {
+		if value, ok := s.oldEnvironment[envVar]; ok {
+			os.Setenv(envVar, value)
+		}
+	}
+}
+
+// osDependendClearenv will clear the environment, and based on platform, will repopulate
+// with whitelisted values previously saved in s.oldEnvironment
+func (s *OsEnvSuite) osDependendClearenv() {
+	os.Clearenv()
+	// Currently, this will only do something if we are running on windows
+	s.setEnviron()
+}
+
 func (s *OsEnvSuite) SetUpSuite(c *gc.C) {
 	s.oldEnvironment = make(map[string]string)
 	for _, envvar := range os.Environ() {
 		parts := strings.SplitN(envvar, "=", 2)
 		s.oldEnvironment[parts[0]] = parts[1]
 	}
-	os.Clearenv()
+	s.osDependendClearenv()
 }
 
 func (s *OsEnvSuite) TearDownSuite(c *gc.C) {
@@ -33,7 +100,7 @@ func (s *OsEnvSuite) TearDownSuite(c *gc.C) {
 }
 
 func (s *OsEnvSuite) SetUpTest(c *gc.C) {
-	os.Clearenv()
+	s.osDependendClearenv()
 }
 
 func (s *OsEnvSuite) TearDownTest(c *gc.C) {


### PR DESCRIPTION
Windows requires a set of environment variables to function properly. This PR adds a whitelist of default environment variables that will get saved, and then preserved on Windows so that tests will work properly.

Without proper environment variables, standard packages such as "os" will sometimes fail, leading to packages failing because no temporary directory/file could be created.

ex on windows:

``` Go
package main

import (
    "os"
    "fmt"
)

func main() {
    fmt.Printf("Tempdir: %s", os.TempDir())
    os.Clearenv()
    fmt.Printf("Tempdir after Clearenv(): %s", os.TempDir())
}
```
