### PR TITLE
checkers: report interface{} nil vs non-nil mismatch correctly

### DIFF
--- a/checkers/deepequal.go
+++ b/checkers/deepequal.go
@@ -125,7 +125,7 @@ func deepValueEqual(path string, v1, v2 reflect.Value, visited map[visit]bool, d
 	case reflect.Interface:
 		if v1.IsNil() || v2.IsNil() {
 			if v1.IsNil() != v2.IsNil() {
-				return false, fmt.Errorf("nil vs non-nil interface mismatch")
+				return false, errorf("nil vs non-nil interface mismatch")
 			}
 			return true, nil
 		}

--- a/checkers/deepequal_test.go
+++ b/checkers/deepequal_test.go
@@ -75,6 +75,7 @@ var deepEqualTests = []DeepEqualTest{
 	{1, nil, false, `mismatch at top level: nil vs non-nil mismatch; obtained 1; expected <nil>`},
 	{fn1, fn3, false, `mismatch at top level: non-nil functions; obtained \(func\(\)\)\(nil\); expected \(func\(\)\)\(0x[0-9a-f]+\)`},
 	{fn3, fn3, false, `mismatch at top level: non-nil functions; obtained \(func\(\)\)\(0x[0-9a-f]+\); expected \(func\(\)\)\(0x[0-9a-f]+\)`},
+	{[]interface{}{nil}, []interface{}{"a"}, false, `mismatch at \[0\]: nil vs non-nil interface mismatch`},
 
 	// Nil vs empty: they're the same (difference from normal DeepEqual)
 	{[]int{}, []int(nil), true, ""},


### PR DESCRIPTION
One occurrence of fmt.Errorf had not been found.
