### PR TITLE
Make auth in MgoSuite optional, disabled by default

### DIFF
--- a/mgo.go
+++ b/mgo.go
@@ -84,6 +84,9 @@ type MgoInstance struct {
 	// EnableJournal enables journaling.
 	EnableJournal bool
 
+	// EnableAuth enables authentication/authorization.
+	EnableAuth bool
+
 	// WithoutV8 is true if we believe this Mongo doesn't actually have the
 	// V8 engine
 	WithoutV8 bool
@@ -193,7 +196,6 @@ func (inst *MgoInstance) run() error {
 
 	mgoport := strconv.Itoa(inst.port)
 	mgoargs := []string{
-		"--auth",
 		"--dbpath", inst.dir,
 		"--port", mgoport,
 		"--nssize", "1",
@@ -202,8 +204,13 @@ func (inst *MgoInstance) run() error {
 		"--nohttpinterface",
 		"--nounixsocket",
 		"--oplogSize", "10",
-		"--keyFile", filepath.Join(inst.dir, "keyfile"),
 		"--ipv6",
+	}
+	if inst.EnableAuth {
+		mgoargs = append(mgoargs,
+			"--auth",
+			"--keyFile", filepath.Join(inst.dir, "keyfile"),
+		)
 	}
 	if !inst.EnableJournal {
 		mgoargs = append(mgoargs, "--nojournal")


### PR DESCRIPTION
The Juju tests mostly don't care about authentication.
By disabling authentication by default, segregating
the tests that do care (i.e. explicit checks for
authentication/authorisation) and enabling authentication
for them, then we can easily run with either Mongo 2.4 or
2.6 despite the changes made to security between the
versions.
