### PR TITLE
Added checker for paths which works on both Windows and Linux

### DIFF
--- a/checkers/file_test.go
+++ b/checkers/file_test.go
@@ -1,4 +1,5 @@
 // Copyright 2013 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
 // Licensed under the LGPLv3, see LICENCE file for details.
 
 package checkers_test
@@ -8,6 +9,8 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 
 	gc "launchpad.net/gocheck"
 
@@ -163,4 +166,123 @@ func (s *FileSuite) TestIsSymlinkWithDir(c *gc.C) {
 	result, message := jc.IsSymlink.Check([]interface{}{c.MkDir()}, nil)
 	c.Assert(result, jc.IsFalse)
 	c.Assert(message, jc.Contains, " is not a symlink")
+}
+
+func (s *FileSuite) TestSamePathWithNumber(c *gc.C) {
+	result, message := jc.SamePath.Check([]interface{}{42, 52}, nil)
+	c.Assert(result, jc.IsFalse)
+	c.Assert(message, gc.Equals, "obtained value is not a string and has no .String(), int:42")
+}
+
+func (s *FileSuite) TestSamePathBasic(c *gc.C) {
+	dir := c.MkDir()
+
+	result, message := jc.SamePath.Check([]interface{}{dir, dir}, nil)
+
+	c.Assert(result, jc.IsTrue)
+	c.Assert(message, gc.Equals, "")
+}
+
+type SamePathLinuxSuite struct{}
+
+var _ = gc.Suite(&SamePathLinuxSuite{})
+
+func (s *SamePathLinuxSuite) SetUpSuite(c *gc.C) {
+	if runtime.GOOS == "windows" {
+		c.Skip("Skipped Linux-intented SamePath tests on Windows.")
+	}
+}
+
+func (s *SamePathLinuxSuite) TestNotSamePathLinuxBasic(c *gc.C) {
+	dir := c.MkDir()
+	path1 := filepath.Join(dir, "Test")
+	path2 := filepath.Join(dir, "test")
+
+	result, message := jc.SamePath.Check([]interface{}{path1, path2}, nil)
+
+	c.Assert(result, jc.IsFalse)
+	c.Assert(message, gc.Equals, "stat "+path1+": no such file or directory")
+}
+
+func (s *SamePathLinuxSuite) TestSamePathLinuxSymlinks(c *gc.C) {
+	file, err := ioutil.TempFile(c.MkDir(), "")
+	c.Assert(err, gc.IsNil)
+	symlinkPath := filepath.Join(filepath.Dir(file.Name()), "a-symlink")
+	err = os.Symlink(file.Name(), symlinkPath)
+
+	result, message := jc.SamePath.Check([]interface{}{file.Name(), symlinkPath}, nil)
+
+	c.Assert(result, jc.IsTrue)
+	c.Assert(message, gc.Equals, "")
+}
+
+type SamePathWindowsSuite struct{}
+
+var _ = gc.Suite(&SamePathWindowsSuite{})
+
+func (s *SamePathWindowsSuite) SetUpSuite(c *gc.C) {
+	if runtime.GOOS != "windows" {
+		c.Skip("Skipped Windows-intented SamePath tests.")
+	}
+}
+
+func (s *SamePathWindowsSuite) TestNotSamePathBasic(c *gc.C) {
+	dir := c.MkDir()
+	path1 := filepath.Join(dir, "notTest")
+	path2 := filepath.Join(dir, "test")
+
+	result, message := jc.SamePath.Check([]interface{}{path1, path2}, nil)
+
+	c.Assert(result, jc.IsFalse)
+	path1 = strings.ToUpper(path1)
+	c.Assert(message, gc.Equals, "GetFileAttributesEx "+path1+": The system cannot find the file specified.")
+}
+
+func (s *SamePathWindowsSuite) TestSamePathWindowsCaseInsensitive(c *gc.C) {
+	dir := c.MkDir()
+	path1 := filepath.Join(dir, "Test")
+	path2 := filepath.Join(dir, "test")
+
+	result, message := jc.SamePath.Check([]interface{}{path1, path2}, nil)
+
+	c.Assert(result, jc.IsTrue)
+	c.Assert(message, gc.Equals, "")
+}
+
+func (s *SamePathWindowsSuite) TestSamePathWindowsFixSlashes(c *gc.C) {
+	result, message := jc.SamePath.Check([]interface{}{"C:/Users", "C:\\Users"}, nil)
+
+	c.Assert(result, jc.IsTrue)
+	c.Assert(message, gc.Equals, "")
+}
+
+func (s *SamePathWindowsSuite) TestSamePathShortenedPaths(c *gc.C) {
+	dir := c.MkDir()
+	dir1, err := ioutil.TempDir(dir, "Programming")
+	defer os.Remove(dir1)
+	c.Assert(err, gc.IsNil)
+	result, message := jc.SamePath.Check([]interface{}{dir + "\\PROGRA~1", dir1}, nil)
+
+	c.Assert(result, jc.IsTrue)
+	c.Assert(message, gc.Equals, "")
+}
+
+func (s *SamePathWindowsSuite) TestSamePathShortenedPathsConsistent(c *gc.C) {
+	dir := c.MkDir()
+	dir1, err := ioutil.TempDir(dir, "Programming")
+	defer os.Remove(dir1)
+	c.Assert(err, gc.IsNil)
+	dir2, err := ioutil.TempDir(dir, "Program Files")
+	defer os.Remove(dir2)
+	c.Assert(err, gc.IsNil)
+
+	result, message := jc.SamePath.Check([]interface{}{dir + "\\PROGRA~1", dir2}, nil)
+
+	c.Assert(result, gc.Not(jc.IsTrue))
+	c.Assert(message, gc.Equals, "Not the same file")
+
+	result, message = jc.SamePath.Check([]interface{}{"C:/PROGRA~2", "C:/Program Files (x86)"}, nil)
+
+	c.Assert(result, jc.IsTrue)
+	c.Assert(message, gc.Equals, "")
 }


### PR DESCRIPTION
This PR includes a checker that fixes path problems like OS-specific separators, case-sensitive files and symlinks.
This is added mostly for compatibility with both windows and linux.
