### PR TITLE
testing/checkers: fix panic in IsTrue

### DIFF
--- a/checkers/bool.go
+++ b/checkers/bool.go
@@ -1,4 +1,4 @@
-// Copyright 2013 Canonical Ltd.
+// Copyright 2011 Canonical Ltd.
 // Licensed under the LGPLv3, see LICENCE file for details.
 
 package checkers
@@ -27,7 +27,9 @@ var IsFalse gc.Checker = gc.Not(IsTrue)
 func (checker *isTrueChecker) Check(params []interface{}, names []string) (result bool, error string) {
 
 	value := reflect.ValueOf(params[0])
-
+	if !value.IsValid() {
+		return false, fmt.Sprintf("expected type bool, received %s", value)
+	}
 	switch value.Kind() {
 	case reflect.Bool:
 		return value.Bool(), ""

--- a/checkers/bool_test.go
+++ b/checkers/bool_test.go
@@ -31,11 +31,15 @@ func (s *BoolSuite) TestIsTrue(c *gc.C) {
 	result, msg = jc.IsTrue.Check([]interface{}{42}, nil)
 	c.Assert(result, gc.Equals, false)
 	c.Assert(msg, gc.Equals, `expected type bool, received type int`)
+
+	result, msg = jc.IsTrue.Check([]interface{}{nil}, nil)
+	c.Assert(result, gc.Equals, false)
+	c.Assert(msg, gc.Equals, `expected type bool, received <invalid Value>`)
 }
 
 func (s *BoolSuite) TestIsFalse(c *gc.C) {
-	c.Assert(false, jc.IsFalse)
-	c.Assert(true, gc.Not(jc.IsFalse))
+	c.Check(false, jc.IsFalse)
+	c.Check(true, gc.Not(jc.IsFalse))
 }
 
 func is42(i int) bool {


### PR DESCRIPTION
Fixes a panic caused by not handling an empty interface value, the zero value for interface{} properly.

This came up with a test case that tried

```
c.Assert(m["somekey", jc.IsTrue)
```

Which would panic if "somekey" was missing from the map.
