### PR TITLE
Make preservation of envvars case insensitive on windows

### DIFF
--- a/osenv.go
+++ b/osenv.go
@@ -72,12 +72,13 @@ func (s *OsEnvSuite) setEnviron() {
 	case "windows":
 		// Lowercase variable names for comparison as they are case
 		// insenstive on windows. Fancy folding not required for ascii.
-		lowerEnv := make(map[string]string)
+		lowerEnv := make(map[string]struct{},
+			len(windowsVariables) + len(testingVariables))
 		for _, envVar := range windowsVariables {
-			lowerEnv[strings.ToLower(envVar)] = envVar
+			lowerEnv[strings.ToLower(envVar)] = struct{}{}
 		}
 		for _, envVar := range testingVariables {
-			lowerEnv[strings.ToLower(envVar)] = envVar
+			lowerEnv[strings.ToLower(envVar)] = struct{}{}
 		}
 		isWhitelisted = func (envVar string) bool {
 			_, ok := lowerEnv[strings.ToLower(envVar)]

--- a/osenv.go
+++ b/osenv.go
@@ -67,16 +67,34 @@ var testingVariables = []string{
 }
 
 func (s *OsEnvSuite) setEnviron() {
-	var envList []string
+	var isWhitelisted func (string) bool
 	switch runtime.GOOS {
 	case "windows":
-		envList = windowsVariables
+		// Lowercase variable names for comparison as they are case
+		// insenstive on windows. Fancy folding not required for ascii.
+		lowerEnv := make(map[string]string)
+		for _, envVar := range windowsVariables {
+			lowerEnv[strings.ToLower(envVar)] = envVar
+		}
+		for _, envVar := range testingVariables {
+			lowerEnv[strings.ToLower(envVar)] = envVar
+		}
+		isWhitelisted = func (envVar string) bool {
+			_, ok := lowerEnv[strings.ToLower(envVar)]
+			return ok
+		}
 	default:
-		envList = []string{}
+		isWhitelisted = func (envVar string) bool {
+			for _, testingVar := range testingVariables {
+				if testingVar == envVar {
+					return true
+				}
+			}
+			return false
+		}
 	}
-	envList = append(envList, testingVariables...)
-	for _, envVar := range envList {
-		if value, ok := s.oldEnvironment[envVar]; ok {
+	for envVar, value := range s.oldEnvironment {
+		if isWhitelisted(envVar) {
 			os.Setenv(envVar, value)
 		}
 	}
@@ -86,7 +104,7 @@ func (s *OsEnvSuite) setEnviron() {
 // with whitelisted values previously saved in s.oldEnvironment
 func (s *OsEnvSuite) osDependendClearenv() {
 	os.Clearenv()
-	// Currently, this will only do something if we are running on windows
+	// Restore any platform required or juju testing variables.
 	s.setEnviron()
 }
 


### PR DESCRIPTION
Treat envvars as case insenstive when whitelisting in OsEnvSuite

Because windows envvars are case insensitive but case preserving, it's possible to have a valid common value, like PATH, which would be accepted by the OS, get scrubbed. This branch changes the whitelisting to use lower cased comparisons on windows.