### PR TITLE
Multiple echo-args calls

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -107,7 +107,7 @@ func PatchExecutable(c *gc.C, patcher CleanupPatcher, execName, script string, e
 		filename = filepath.Join(dir, execName)
 	}
 	os.Remove(filename + ".out")
-	err := ioutil.WriteFile(filename, []byte(script), 0755)
+	err := ioutil.WriteFile(filename, []byte(script), 0644)
 	c.Assert(err, gc.IsNil)
 
 	if len(exitCodes) > 0 {
@@ -117,7 +117,7 @@ func PatchExecutable(c *gc.C, patcher CleanupPatcher, execName, script string, e
 			codes[i] = strconv.Itoa(code)
 		}
 		s := strings.Join(codes, ";") + ";"
-		err = ioutil.WriteFile(filename, []byte(s), 0755)
+		err = ioutil.WriteFile(filename, []byte(s), 0644)
 		c.Assert(err, gc.IsNil)
 		patcher.AddCleanup(func(*gc.C) {
 			os.Remove(filename)


### PR DESCRIPTION
Now can have multiple calls to an echo-args patched command and record all outputs. Can also supply optional exit codes so you can emulate a sequence of calls, some failing, some executing OK.