### PR TITLE
Correct licence header in stub.go and stub_test.go to LGPLv3

### DIFF
--- a/stub.go
+++ b/stub.go
@@ -1,5 +1,5 @@
 // Copyright 2015 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package testing
 

--- a/stub_test.go
+++ b/stub_test.go
@@ -1,5 +1,5 @@
 // Copyright 2015 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package testing_test
 


### PR DESCRIPTION
Correct two licence headers from AGPL to LGPL as noted by ubuntu release review:

https://bugs.launchpad.net/juju-core/+bug/1442132

(Review request: http://reviews.vapour.ws/r/1415/)