### PR TITLE
testing: do not use default writer in LoggingSuite

### DIFF
--- a/log.go
+++ b/log.go
@@ -49,9 +49,18 @@ func (s *LoggingSuite) SetUpTest(c *gc.C) {
 func (s *LoggingSuite) TearDownTest(c *gc.C) {
 }
 
+type discardWriter struct{}
+
+func (discardWriter) Write(level loggo.Level, name, filename string, line int, timestamp time.Time, message string) {
+}
+
 func (s *LoggingSuite) setUp(c *gc.C) {
 	loggo.ResetWriters()
-	loggo.ReplaceDefaultWriter(&gocheckWriter{c})
+	// Don't use the default writer for the test logging, which
+	// means we can still get logging output from tests that
+	// replace the default writer.
+	loggo.ReplaceDefaultWriter(discardWriter{})
+	loggo.RegisterWriter("loggingsuite", &gocheckWriter{c}, loggo.TRACE)
 	loggo.ResetLoggers()
 	err := loggo.ConfigureLoggers(logConfig)
 	c.Assert(err, gc.IsNil)


### PR DESCRIPTION
Currently when testing a juju command that uses cmd.Log, the
logging test output is suppressed because the logging setup
changes the default writer. This PR changes things so that
the test logger uses a different writer so we can still see
debugging log messages in such tests.

(Review request: http://reviews.vapour.ws/r/1724/)