### PR TITLE
Various test fix on CentOS

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -13,6 +13,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/juju/utils"
+
 	gc "gopkg.in/check.v1"
 )
 
@@ -50,7 +52,7 @@ argfile="$name.out"
 exitcodesfile="$name.exitcodes"
 printf "%s" $name | tee -a $argfile
 for arg in "$@"; do
-  printf " \"%s\""  "$arg" | tee -a $argfile
+  printf " '%s'" "$arg" | tee -a $argfile
 done
 printf "\n" | tee -a $argfile
 if [ -f $exitcodesfile ]
@@ -183,11 +185,12 @@ func AssertEchoArgs(c *gc.C, execName string, args ...string) {
 	// Create expected output string
 	expected := execName
 	for _, arg := range args {
-		expected = fmt.Sprintf("%s %q", expected, arg)
+		expected = fmt.Sprintf("%s %s", expected, utils.ShQuote(arg))
 	}
 
 	// Check that the expected and the first line of actual output are the same
 	actual := strings.TrimSuffix(lines[0], "\r")
+
 	c.Assert(actual, gc.Equals, expected)
 
 	// Write out the remaining lines for the next check

--- a/mgo.go
+++ b/mgo.go
@@ -295,7 +295,7 @@ func (inst *MgoInstance) run() error {
 }
 
 func getMongod() (string, error) {
-	// The last two paths are needed in tests where PATH is being completely removed
+	// The last path is needed in tests on CentOS where PATH is being completely removed
 	paths := []string{"mongod", "/usr/lib/juju/bin/mongod", "/usr/local/bin/mongod"}
 	if path := os.Getenv("JUJU_MONGOD"); path != "" {
 		paths = append([]string{path}, paths...)

--- a/mgo.go
+++ b/mgo.go
@@ -295,7 +295,8 @@ func (inst *MgoInstance) run() error {
 }
 
 func getMongod() (string, error) {
-	paths := []string{"mongod", "/usr/lib/juju/bin/mongod"}
+	// The last two paths are needed in tests where PATH is being completely removed
+	paths := []string{"mongod", "/usr/lib/juju/bin/mongod", "/usr/local/bin/mongod"}
 	if path := os.Getenv("JUJU_MONGOD"); path != "" {
 		paths = append([]string{path}, paths...)
 	}


### PR DESCRIPTION
Strings were generated with 2 sets of quotes in tests. This patch resolve this problem.

There is a difference between "%q" in bash and "%q" in Go. In bash "%q" will print the associated argument shell-quoted and in Go "%q" will print the associated argument double-quoted.  

For example:
```printf "%q" "hello world"``` will print ```hello\ world```

```fmt.Printf("%q", "hello world")``` will print ```"hello world"```

ShQuote quotes the string so no metacharacters within string will be interpreted as such.

Also, I added two more paths for mongod. These are needed in tests where PATH is being completely removed and to get the unit tests going on CentOS