### PR TITLE
Add Stub.PopNoErr() and Stub.CheckNoCalls().

### DIFF
--- a/stub.go
+++ b/stub.go
@@ -4,6 +4,7 @@
 package testing
 
 import (
+	"fmt"
 	"sync"
 
 	jc "github.com/juju/testing/checkers"
@@ -123,12 +124,13 @@ func (f *Stub) NextErr() error {
 }
 
 // PopNoErr pops off the next error without returning it. If the error
-// is not nil then PopNoErr will fail an assertion.
+// is not nil then PopNoErr will panic.
 //
 // PopNoErr is useful in stub methods that do not return an error.
-func (f *Stub) PopNoErr(c *gc.C) {
-	err := f.NextErr()
-	c.Assert(err, jc.ErrorIsNil)
+func (f *Stub) PopNoErr() {
+	if err := f.NextErr(); err != nil {
+		panic(fmt.Sprintf("expected a nil error, got %v", err))
+	}
 }
 
 func (f *Stub) addCall(rcvr interface{}, funcName string, args []interface{}) {

--- a/stub.go
+++ b/stub.go
@@ -4,7 +4,6 @@
 package testing
 
 import (
-	"fmt"
 	"sync"
 
 	jc "github.com/juju/testing/checkers"
@@ -127,10 +126,9 @@ func (f *Stub) NextErr() error {
 // is not nil then PopNoErr panics.
 //
 // PopNoErr is useful in stub methods that do not return an error.
-func (f *Stub) PopNoErr() {
-	if err := f.NextErr(); err != nil {
-		panic(fmt.Sprintf("unexpected error set: %v", err))
-	}
+func (f *Stub) PopNoErr(c *gc.C) {
+	err := f.NextErr()
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (f *Stub) addCall(rcvr interface{}, funcName string, args []interface{}) {

--- a/stub.go
+++ b/stub.go
@@ -222,6 +222,11 @@ func (f *Stub) CheckCallNames(c *gc.C, expected ...string) bool {
 	return c.Check(funcNames, jc.DeepEquals, expected)
 }
 
+// CheckNoCalls verifies that none of the stub's methods have been called.
+func (f *Stub) CheckNoCalls(c *gc.C) {
+	f.CheckCalls(c, nil)
+}
+
 // CheckErrors verifies that the list of errors is matches the expected list.
 func (f *Stub) CheckErrors(c *gc.C, expected ...error) bool {
 	f.mu.Lock()

--- a/stub.go
+++ b/stub.go
@@ -123,7 +123,7 @@ func (f *Stub) NextErr() error {
 }
 
 // PopNoErr pops off the next error without returning it. If the error
-// is not nil then PopNoErr panics.
+// is not nil then PopNoErr will fail an assertion.
 //
 // PopNoErr is useful in stub methods that do not return an error.
 func (f *Stub) PopNoErr(c *gc.C) {

--- a/stub.go
+++ b/stub.go
@@ -4,6 +4,7 @@
 package testing
 
 import (
+	"fmt"
 	"sync"
 
 	jc "github.com/juju/testing/checkers"
@@ -120,6 +121,16 @@ func (f *Stub) NextErr() error {
 	err := f.errors[0]
 	f.errors = f.errors[1:]
 	return err
+}
+
+// PopNoErr pops off the next error without returning it. If the error
+// is not nil then PopNoErr panics.
+//
+// PopNoErr is useful in stub methods that do not return an error.
+func (f *Stub) PopNoErr() {
+	if err := f.NextErr(); err != nil {
+		panic(fmt.Sprintf("unexpected error set: %v", err))
+	}
 }
 
 func (f *Stub) addCall(rcvr interface{}, funcName string, args []interface{}) {

--- a/stub_test.go
+++ b/stub_test.go
@@ -110,6 +110,37 @@ func (s *stubSuite) TestNextErrEmbeddedMixed(c *gc.C) {
 	c.Check(err4, gc.Equals, exp2)
 }
 
+func (s *stubSuite) TestPopNoErrOkay(c *gc.C) {
+	exp1 := errors.New("<failure 1>")
+	exp2 := errors.New("<failure 2>")
+	s.stub.SetErrors(exp1, nil, exp2)
+
+	err1 := s.stub.NextErr()
+	s.stub.PopNoErr()
+	err2 := s.stub.NextErr()
+
+	c.Check(err1, gc.Equals, exp1)
+	c.Check(err2, gc.Equals, exp2)
+}
+
+func (s *stubSuite) TestPopNoErrEmpty(c *gc.C) {
+	s.stub.PopNoErr()
+	err := s.stub.NextErr()
+
+	c.Check(err, jc.ErrorIsNil)
+}
+
+func (s *stubSuite) TestPopNoErrPanic(c *gc.C) {
+	failure := errors.New("<failure>")
+	s.stub.SetErrors(failure)
+
+	f := func() {
+		s.stub.PopNoErr()
+	}
+
+	c.Check(f, gc.PanicMatches, `unexpected error set: <failure>`)
+}
+
 func (s *stubSuite) TestAddCallRecorded(c *gc.C) {
 	s.stub.AddCall("aFunc", 1, 2, 3)
 

--- a/stub_test.go
+++ b/stub_test.go
@@ -423,3 +423,11 @@ func (s *stubSuite) TestCheckCallNamesWrongName(c *gc.C) {
 	c.ExpectFailure(`the "standard" Stub.CheckCallNames call should fail here`)
 	s.stub.CheckCallNames(c, "first", "second", "third")
 }
+
+func (s *stubSuite) TestCheckNoCalls(c *gc.C) {
+	s.stub.CheckNoCalls(c)
+
+	s.stub.AddCall("method", "arg")
+	c.ExpectFailure(`the "standard" Stub.CheckNoCalls call should fail here`)
+	s.stub.CheckNoCalls(c)
+}

--- a/stub_test.go
+++ b/stub_test.go
@@ -116,7 +116,7 @@ func (s *stubSuite) TestPopNoErrOkay(c *gc.C) {
 	s.stub.SetErrors(exp1, nil, exp2)
 
 	err1 := s.stub.NextErr()
-	s.stub.PopNoErr()
+	s.stub.PopNoErr(c)
 	err2 := s.stub.NextErr()
 
 	c.Check(err1, gc.Equals, exp1)
@@ -124,7 +124,7 @@ func (s *stubSuite) TestPopNoErrOkay(c *gc.C) {
 }
 
 func (s *stubSuite) TestPopNoErrEmpty(c *gc.C) {
-	s.stub.PopNoErr()
+	s.stub.PopNoErr(c)
 	err := s.stub.NextErr()
 
 	c.Check(err, jc.ErrorIsNil)
@@ -134,11 +134,8 @@ func (s *stubSuite) TestPopNoErrPanic(c *gc.C) {
 	failure := errors.New("<failure>")
 	s.stub.SetErrors(failure)
 
-	f := func() {
-		s.stub.PopNoErr()
-	}
-
-	c.Check(f, gc.PanicMatches, `unexpected error set: <failure>`)
+	c.ExpectFailure(`Stub.PopNoErr() should fail when there is an error`)
+	s.stub.PopNoErr(c)
 }
 
 func (s *stubSuite) TestAddCallRecorded(c *gc.C) {

--- a/stub_test.go
+++ b/stub_test.go
@@ -116,7 +116,7 @@ func (s *stubSuite) TestPopNoErrOkay(c *gc.C) {
 	s.stub.SetErrors(exp1, nil, exp2)
 
 	err1 := s.stub.NextErr()
-	s.stub.PopNoErr(c)
+	s.stub.PopNoErr()
 	err2 := s.stub.NextErr()
 
 	c.Check(err1, gc.Equals, exp1)
@@ -124,7 +124,7 @@ func (s *stubSuite) TestPopNoErrOkay(c *gc.C) {
 }
 
 func (s *stubSuite) TestPopNoErrEmpty(c *gc.C) {
-	s.stub.PopNoErr(c)
+	s.stub.PopNoErr()
 	err := s.stub.NextErr()
 
 	c.Check(err, jc.ErrorIsNil)
@@ -134,8 +134,10 @@ func (s *stubSuite) TestPopNoErrPanic(c *gc.C) {
 	failure := errors.New("<failure>")
 	s.stub.SetErrors(failure)
 
-	c.ExpectFailure(`Stub.PopNoErr() should fail when there is an error`)
-	s.stub.PopNoErr(c)
+	f := func() {
+		s.stub.PopNoErr()
+	}
+	c.Check(f, gc.PanicMatches, `expected a nil error, got .*`)
 }
 
 func (s *stubSuite) TestAddCallRecorded(c *gc.C) {


### PR DESCRIPTION
Add convenience methods Stub.PopNoErr() and Stub.CheckNoCalls().  These methods help make intent more obvious and encourage a correct approach in a couple common cases.

(Review request: http://reviews.vapour.ws/r/3162/)