### PR TITLE
testing: add constant to detect race detector

### DIFF
--- a/checkers/bool_test.go
+++ b/checkers/bool_test.go
@@ -34,7 +34,7 @@ func (s *BoolSuite) TestIsTrue(c *gc.C) {
 
 	result, msg = jc.IsTrue.Check([]interface{}{nil}, nil)
 	c.Assert(result, gc.Equals, false)
-	c.Assert(msg, gc.Equals, `expected type bool, received <invalid Value>`)
+	c.Assert(msg, gc.Matches, `expected type bool, received <invalid .*Value>`)
 }
 
 func (s *BoolSuite) TestIsFalse(c *gc.C) {

--- a/norace.go
+++ b/norace.go
@@ -1,0 +1,8 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+// +build !race
+
+package testing
+
+const RaceEnabled = false

--- a/race.go
+++ b/race.go
@@ -1,0 +1,8 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+// +build race
+
+package testing
+
+const RaceEnabled = true


### PR DESCRIPTION
Some juju tests need to be skipped because they do not pass under
the race detector. To simplify this, add a constant so we can do:

     if testing.RaceEnabled {
            t.Skip("skipping package test under race detector, see LP NNNNN")
     }
     // normal gocheck stub

While I'm here, fix a test failure with testing/checkers under Go 1.4+

(Review request: http://reviews.vapour.ws/r/3202/)