### PR TITLE
testing: add GOVERSION constant

### DIFF
--- a/goversion12.go
+++ b/goversion12.go
@@ -1,0 +1,9 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+// +build go1.2
+// +build !go1.3,!go1.4,!go1.5
+
+package testing
+
+const GOVERSION = 1.2

--- a/goversion13.go
+++ b/goversion13.go
@@ -1,0 +1,9 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+// +build go1.3
+// +build !go1.4,!go1.5
+
+package testing
+
+const GOVERSION = 1.3

--- a/goversion14.go
+++ b/goversion14.go
@@ -1,0 +1,9 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+// +build go1.4
+// +build !go1.5
+
+package testing
+
+const GOVERSION = 1.4

--- a/goversion15.go
+++ b/goversion15.go
@@ -1,0 +1,8 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+// +build go1.5
+
+package testing
+
+const GOVERSION = 1.5


### PR DESCRIPTION
Add a constant that can be used to conditionally skip tests. eg.

    if testing.GOVERSION == 1.5 {
          t.Skip("skipping package, see LP NNN")
    }

Additional note: GOVERSION is an untyped constant, not an IEEE floating
point value. It is safe to do comparisons on it like equals and greater
than/less than without concerns about precision.

(Review request: http://reviews.vapour.ws/r/3257/)