### PR TITLE
juju/testing: Don't panic on Mongo test setup

### DIFF
--- a/checkers/bool_test.go
+++ b/checkers/bool_test.go
@@ -34,7 +34,7 @@ func (s *BoolSuite) TestIsTrue(c *gc.C) {
 
 	result, msg = jc.IsTrue.Check([]interface{}{nil}, nil)
 	c.Assert(result, gc.Equals, false)
-	c.Assert(msg, gc.Equals, `expected type bool, received <invalid Value>`)
+	c.Assert(msg, gc.Matches, `expected type bool, received <invalid .*Value>`)
 }
 
 func (s *BoolSuite) TestIsFalse(c *gc.C) {

--- a/mgo.go
+++ b/mgo.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/juju/loggo"
+	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2"
@@ -482,7 +483,9 @@ func MgoDialInfo(certs *Certs, addrs ...string) *mgo.DialInfo {
 
 func (s *MgoSuite) SetUpTest(c *gc.C) {
 	mgo.ResetStats()
-	s.Session = MgoServer.MustDial()
+	var err error
+	s.Session, err = MgoServer.Dial()
+	c.Assert(err, jc.ErrorIsNil)
 	dropAll(s.Session)
 }
 

--- a/mgo.go
+++ b/mgo.go
@@ -496,6 +496,7 @@ func (inst *MgoInstance) Reset() {
 	// just start it again.
 	if inst.Addr() == "" {
 		if err := inst.Start(inst.certs); err != nil {
+			logger.Debugf("inst.Start(%v) failed with %v", inst.certs, err)
 			panic(err)
 		}
 		return


### PR DESCRIPTION
When dialling Mongo, return and assert err is nil instead of calling
MustDial, which panics.

(Review request: http://reviews.vapour.ws/r/3332/)