### PR TITLE
Add a panic() if AddCleanup is unsafe.

### DIFF
--- a/cleanup.go
+++ b/cleanup.go
@@ -76,9 +76,6 @@ func (s *CleanupSuite) AddCleanup(cleanup CleanupFunc) {
 		s.suiteStack = append(s.suiteStack, cleanup)
 		return
 	}
-	if s != s.testSuite {
-		panic("unsafe to call AddCleanup from non pointer receiver test")
-	}
 	s.testStack = append(s.testStack, cleanup)
 }
 

--- a/cleanup.go
+++ b/cleanup.go
@@ -18,10 +18,13 @@ type cleanupStack []CleanupFunc
 type CleanupSuite struct {
 	testStack  cleanupStack
 	suiteStack cleanupStack
+	suiteSuite *CleanupSuite
+	testSuite  *CleanupSuite
 }
 
 func (s *CleanupSuite) SetUpSuite(c *gc.C) {
 	s.suiteStack = nil
+	s.suiteSuite = s
 }
 
 func (s *CleanupSuite) TearDownSuite(c *gc.C) {
@@ -30,6 +33,7 @@ func (s *CleanupSuite) TearDownSuite(c *gc.C) {
 
 func (s *CleanupSuite) SetUpTest(c *gc.C) {
 	s.testStack = nil
+	s.testSuite = s
 }
 
 func (s *CleanupSuite) TearDownTest(c *gc.C) {
@@ -45,12 +49,18 @@ func (s *CleanupSuite) callStack(c *gc.C, stack cleanupStack) {
 // AddCleanup pushes the cleanup function onto the stack of functions to be
 // called during TearDownTest.
 func (s *CleanupSuite) AddCleanup(cleanup CleanupFunc) {
+	if s != s.testSuite {
+		panic("unsafe to call AddCleanup from non pointer receiver test")
+	}
 	s.testStack = append(s.testStack, cleanup)
 }
 
 // AddSuiteCleanup pushes the cleanup function onto the stack of functions to
 // be called during TearDownSuite.
 func (s *CleanupSuite) AddSuiteCleanup(cleanup CleanupFunc) {
+	if s != s.testSuite {
+		panic("unsafe to call AddSuiteCleanup from non pointer receiver test")
+	}
 	s.suiteStack = append(s.suiteStack, cleanup)
 }
 

--- a/cleanup_test.go
+++ b/cleanup_test.go
@@ -113,3 +113,27 @@ func (s *cleanupSuite) TestPatchValueFunction(c *gc.C) {
 	// being called again.
 	s.SetUpTest(c)
 }
+
+func (s cleanupSuite) TestAddCleanupPanicIfUnsafe(c *gc.C) {
+	// It is unsafe to call AddCleanup when the test itself is not a
+	// pointer receiver, because AddCleanup modifies the s.testStack
+	// attribute, but in a non-pointer receiver, that object is lost when
+	// the Test function returns.
+	// This Test must, itself, be a non pointer receiver to trigger this
+	noopCleanup := func(*gc.C) {}
+	c.Assert(func() { s.AddCleanup(noopCleanup) },
+		gc.PanicMatches,
+		"unsafe to call AddCleanup from non pointer receiver test")
+}
+
+func (s cleanupSuite) TestAddSuiteCleanupPanicIfUnsafe(c *gc.C) {
+	// It is unsafe to call AddSuiteCleanup when the test itself is not a
+	// pointer receiver, because AddSuiteCleanup modifies the s.suiteStack
+	// attribute, but in a non-pointer receiver, that object is lost when
+	// the Test function returns.
+	// This Test must, itself, be a non pointer receiver to trigger this
+	noopCleanup := func(*gc.C) {}
+	c.Assert(func() { s.AddSuiteCleanup(noopCleanup) },
+		gc.PanicMatches,
+		"unsafe to call AddSuiteCleanup from non pointer receiver test")
+}

--- a/home_test.go
+++ b/home_test.go
@@ -25,11 +25,17 @@ var _ = gc.Suite(&fakeHomeSuite{})
 func (s *fakeHomeSuite) SetUpSuite(c *gc.C) {
 	s.IsolationSuite.SetUpSuite(c)
 	s.fakeHomeSuite = testing.FakeHomeSuite{}
+	s.fakeHomeSuite.SetUpSuite(c)
 }
 
 func (s *fakeHomeSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 	utils.SetHome("/tmp/tests")
+}
+
+func (s *fakeHomeSuite) TearDownSuite(c *gc.C) {
+	s.fakeHomeSuite.TearDownSuite(c)
+	s.IsolationSuite.TearDownSuite(c)
 }
 
 func (s *fakeHomeSuite) TestHomeCreated(c *gc.C) {


### PR DESCRIPTION
If you call AddCleanup from a Test that uses a non-pointer receiver, then the cleanup
will actually never be called, because the original suite is no longer around.

Also, make AddCleanup automatically act like AddSuiteCleanup if it is called while we aren't inside a Test context. That way thinks like PatchValue actually work like we think they do, rather than having them just not work at all.