### PR TITLE
httptesting: fix for Go 1.6

### DIFF
--- a/httptesting/http.go
+++ b/httptesting/http.go
@@ -217,13 +217,15 @@ func DoRequest(c *gc.C, p DoRequestParams) *httptest.ResponseRecorder {
 		return nil
 	}
 	defer resp.Body.Close()
-	var rec httptest.ResponseRecorder
-	rec.HeaderMap = resp.Header
-	rec.Code = resp.StatusCode
-	rec.Body = new(bytes.Buffer)
+	rec := httptest.NewRecorder()
+	h := rec.Header()
+	for k, v := range resp.Header {
+		h[k] = v
+	}
+	rec.WriteHeader(resp.StatusCode)
 	_, err := io.Copy(rec.Body, resp.Body)
 	c.Assert(err, jc.ErrorIsNil)
-	return &rec
+	return rec
 }
 
 // Do invokes a request on the given handler with the given


### PR DESCRIPTION
The httptest.ResponseRecorder type has become more
sophisticated, and our code was being a bit devious
by constructing one without using the expected methods.

Fix by using the expected methods to make the ResponseRecorder.

We should eventually remove our use of ResponseRecorder entirely
and fix all the code that uses httptesting, but we don't
need to bite that bullet quite yet.

(Review request: http://reviews.vapour.ws/r/4317/)