### PR TITLE
Don't drop and recreate the database between tests

### DIFF
--- a/cleanup.go
+++ b/cleanup.go
@@ -32,6 +32,7 @@ func (s *CleanupSuite) SetUpSuite(c *gc.C) {
 
 func (s *CleanupSuite) TearDownSuite(c *gc.C) {
 	s.callStack(c, s.suiteStack)
+	s.suiteStack = nil
 	s.origSuite = nil
 	s.tornDown = true
 }
@@ -44,6 +45,7 @@ func (s *CleanupSuite) SetUpTest(c *gc.C) {
 
 func (s *CleanupSuite) TearDownTest(c *gc.C) {
 	s.callStack(c, s.testStack)
+	s.testStack = nil
 	s.inTest = false
 }
 

--- a/mgo.go
+++ b/mgo.go
@@ -526,7 +526,7 @@ func clearCollections(db *mgo.Database) error {
 		logger.Debugf("    clearing collection: %v", name)
 		collection := db.C(name)
 		_, err = collection.RemoveAll(bson.M{})
-		if err != nil && strings.HasPrefix(err.Error(), "cannot remove from a capped collection:") {
+		if err != nil && strings.Contains(err.Error(), "remove from a capped collection") {
 			// Ugh - there's no other way to detect capped collections that I can find.
 			err := clearCappedCollection(collection)
 			if err != nil {

--- a/mgo.go
+++ b/mgo.go
@@ -356,7 +356,6 @@ func MgoTestPackage(t *testing.T, certs *Certs) {
 }
 
 func (s *MgoSuite) SetUpSuite(c *gc.C) {
-	c.Logf("Setting up mgosuite")
 	if MgoServer.addr == "" {
 		c.Fatalf("No Mongo Server Address, MgoSuite tests must be run with MgoTestPackage")
 	}

--- a/mgo.go
+++ b/mgo.go
@@ -415,7 +415,9 @@ func readLastLines(prefix string, r io.Reader, n int) []string {
 func (s *MgoSuite) TearDownSuite(c *gc.C) {
 	err := MgoServer.Reset()
 	c.Assert(err, jc.ErrorIsNil)
-	s.Session.Close()
+	if s.Session != nil {
+		s.Session.Close()
+	}
 	for i := 0; ; i++ {
 		stats := mgo.GetStats()
 		if stats.SocketsInUse == 0 && stats.SocketsAlive == 0 {

--- a/mgo.go
+++ b/mgo.go
@@ -360,8 +360,6 @@ func (s *MgoSuite) SetUpSuite(c *gc.C) {
 	// Make tests that use password authentication faster.
 	utils.FastInsecureHash = true
 	mgo.ResetStats()
-	var err error
-	c.Logf("mgo.SetupSuite - %#v", MgoServer)
 	session, err := MgoServer.Dial()
 	c.Assert(err, jc.ErrorIsNil)
 	dropAll(session)
@@ -549,7 +547,6 @@ func clearCappedCollection(collection *mgo.Collection) error {
 func (s *MgoSuite) SetUpTest(c *gc.C) {
 	mgo.ResetStats()
 	var err error
-	c.Logf("mgo.SetupTest - %#v", MgoServer)
 	s.Session, err = MgoServer.Dial()
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/mgo.go
+++ b/mgo.go
@@ -505,7 +505,6 @@ func clearDatabases(session *mgo.Session) error {
 		return errors.Trace(err)
 	}
 	for _, name := range databases {
-		logger.Debugf("clearing database: %v", name)
 		err = clearCollections(session.DB(name))
 		if err != nil {
 			return errors.Trace(err)
@@ -523,7 +522,6 @@ func clearCollections(db *mgo.Database) error {
 		if strings.HasPrefix(name, "system.") {
 			continue
 		}
-		logger.Debugf("    clearing collection: %v", name)
 		collection := db.C(name)
 		_, err = collection.RemoveAll(bson.M{})
 		if err != nil && strings.Contains(err.Error(), "remove from a capped collection") {

--- a/mgo.go
+++ b/mgo.go
@@ -665,6 +665,7 @@ func isUnauthorized(err error) bool {
 func (s *MgoSuite) TearDownTest(c *gc.C) {
 	err := s.Session.Ping()
 	if err != nil {
+		// The test has killed the server - reconnect.
 		s.Session.Close()
 		s.Session, err = MgoServer.Dial()
 		c.Assert(err, jc.ErrorIsNil)

--- a/mgo.go
+++ b/mgo.go
@@ -671,7 +671,14 @@ func isUnauthorized(err error) bool {
 }
 
 func (s *MgoSuite) TearDownTest(c *gc.C) {
-	clearDatabases(s.Session)
+	err := s.Session.Ping()
+	if err != nil {
+		s.Session.Close()
+		s.Session, err = MgoServer.Dial()
+		c.Assert(err, jc.ErrorIsNil)
+	}
+	err = clearDatabases(s.Session)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 // FindTCPPort finds an unused TCP port and returns it.

--- a/mgo.go
+++ b/mgo.go
@@ -520,7 +520,7 @@ func clearCollections(db *mgo.Database) error {
 		return errors.Trace(err)
 	}
 	for _, name := range collectionNames {
-		if strings.HasPrefix(name, "txns") {
+		if strings.HasPrefix(name, "system.") {
 			continue
 		}
 		logger.Debugf("    clearing collection: %v", name)

--- a/mgo.go
+++ b/mgo.go
@@ -89,9 +89,6 @@ type MgoInstance struct {
 	// the mongod application
 	Params []string
 
-	// EnableJournal enables journaling.
-	EnableJournal bool
-
 	// EnableAuth enables authentication/authorization.
 	EnableAuth bool
 
@@ -221,9 +218,6 @@ func (inst *MgoInstance) run() error {
 			"--auth",
 			"--keyFile", filepath.Join(inst.dir, "keyfile"),
 		)
-	}
-	if !inst.EnableJournal {
-		mgoargs = append(mgoargs, "--nojournal")
 	}
 	if inst.certs != nil {
 		mgoargs = append(mgoargs,

--- a/mgo.go
+++ b/mgo.go
@@ -501,6 +501,7 @@ func clearDatabases(session *mgo.Session) error {
 		return errors.Trace(err)
 	}
 	for _, name := range databases {
+		logger.Debugf("clearing database: %v", name)
 		err = clearCollections(session.DB(name))
 		if err != nil {
 			return errors.Trace(err)
@@ -515,6 +516,10 @@ func clearCollections(db *mgo.Database) error {
 		return errors.Trace(err)
 	}
 	for _, name := range collectionNames {
+		if strings.HasPrefix(name, "txns") {
+			continue
+		}
+		logger.Debugf("    clearing collection: %v", name)
 		collection := db.C(name)
 		_, err = collection.RemoveAll(bson.M{})
 		if err != nil {


### PR DESCRIPTION
In Mongo 3.2 creating collections and indexes and dropping databases is ~100x slower. Rather than requiring tests to recreate all of the collections and indexes for each test, clear out the data from all collections between tests.

Part of fixing LP-1573294: https://bugs.launchpad.net/juju-core/+bug/1573294
(And related Mongo bug: https://jira.mongodb.org/browse/SERVER-21198)

Also, ensure that test/suite cleanup callbacks are only called once - there are some tests that call setup/teardown during the test (yuck), which meant that the cleanups were done multiple times.

(Review request: http://reviews.vapour.ws/r/4890/)