### PR TITLE
testing: pass --nojournal to testing mongodb

### DIFF
--- a/mgo.go
+++ b/mgo.go
@@ -201,6 +201,7 @@ func (inst *MgoInstance) run() error {
 		"--port", mgoport,
 		"--nssize", "1",
 		"--noprealloc",
+		"--nojournal",
 		"--smallfiles",
 		"--nohttpinterface",
 		"--oplogSize", "10",


### PR DESCRIPTION
We disabled preallocation of data files and reduce the size of the .ns
file (whatever that is), but on startup mongodb will still try to zero
out the journal 8kb at a time.

If you don't have /tmp mounted on tmpfs your tests will be dominated by
the time to zero this backing store.

Disable the journal for testing mongodb's

(Review request: http://reviews.vapour.ws/r/4986/)