### PR TITLE
Added BSONEquals checker

### DIFF
--- a/checkers/codec.go
+++ b/checkers/codec.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2/bson"
 	"gopkg.in/yaml.v2"
 )
 
@@ -15,6 +16,17 @@ type codecEqualChecker struct {
 	name      string
 	marshal   func(interface{}) ([]byte, error)
 	unmarshal func([]byte, interface{}) error
+}
+
+// BSONEquals defines a checker that checks whether a byte slice, when
+// unmarshaled as BSON, is equal to the given value. Rather than
+// unmarshaling into something of the expected body type, we reform
+// the expected body in BSON and back to interface{} so we can check
+// the whole content. Otherwise we lose information when unmarshaling.
+var BSONEquals = &codecEqualChecker{
+	name:      "BSONEquals",
+	marshal:   bson.Marshal,
+	unmarshal: bson.Unmarshal,
 }
 
 // JSONEquals defines a checker that checks whether a byte slice, when


### PR DESCRIPTION
This checker matches the analogous JSONEquals and YAMLEquals checkers.

(Review request: http://reviews.vapour.ws/r/5067/)