### PR TITLE
lp:1596045 handle CRLF in mongo version line

### DIFF
--- a/mgo.go
+++ b/mgo.go
@@ -338,9 +338,16 @@ func detectMongoVersion() (version.Number, error) {
 	if err != nil {
 		return version.Zero, errors.Trace(err)
 	}
-	parts := strings.SplitN(string(output), "\n", 2)
-	// There's guaranteed to be at least one element, even if output's empty.
-	versionLine := parts[0]
+	// Read the first line of the output with a scanner (to handle
+	// newlines in a cross-platform way).
+	scanner := bufio.NewScanner(bytes.NewReader(output))
+	versionLine := ""
+	if scanner.Scan() {
+		versionLine = scanner.Text()
+	}
+	if scanner.Err() != nil {
+		return version.Zero, errors.Trace(scanner.Err())
+	}
 	if !strings.HasPrefix(versionLine, versionLinePrefix) {
 		return version.Zero, errors.New("couldn't get mongod version - no version line")
 	}


### PR DESCRIPTION
The old code was splitting on \n which meant that a \r character was
left on the version line on windows. Using a bufio.Scanner handles the
newlines in a cross-platform way.

(Review request: http://reviews.vapour.ws/r/5163/)