### PR TITLE
Bump mongo error output to 100 lines

### DIFF
--- a/mgo.go
+++ b/mgo.go
@@ -279,9 +279,9 @@ func (inst *MgoInstance) run() error {
 			}
 			listening <- err
 		}
-		// Capture the last 20 lines of output from mongod, to log
+		// Capture the last 100 lines of output from mongod, to log
 		// in the event of unclean exit.
-		lines := readLastLines(prefix, io.MultiReader(&buf, out), 20)
+		lines := readLastLines(prefix, io.MultiReader(&buf, out), 100)
 		err = server.Wait()
 		exitErr, _ := err.(*exec.ExitError)
 		if err == nil || exitErr != nil && exitErr.Exited() {


### PR DESCRIPTION
When mongo exits with an error we output 20 lines of it's output. This
bumps that up to 100 lines to provide more context as to why mongo
errored.