### PR TITLE
MongoDB needs --key=value not --key value now 

### DIFF
--- a/mgo.go
+++ b/mgo.go
@@ -230,7 +230,7 @@ func (inst *MgoInstance) run() error {
 		mgoargs = append(mgoargs,
 			"--sslOnNormalPorts",
 			"--sslPEMKeyFile", filepath.Join(inst.dir, "server.pem"),
-			"--sslPEMKeyPassword", "ignored")
+			"--sslPEMKeyPassword=ignored")
 	}
 	version, err := mongoVersion.Get()
 	if err != nil {


### PR DESCRIPTION
...because of a change to the Boost libraries. Tested on Yakkity and Xenial (bug showed up in Yakkity).

See https://bugs.launchpad.net/ubuntu/+source/juju-mongodb3.2/+bug/1581284 for background.