### PR TITLE
Fixes for replicaset

### DIFF
--- a/mgo.go
+++ b/mgo.go
@@ -248,7 +248,7 @@ func (inst *MgoInstance) run() error {
 		return err
 	}
 	logger.Debugf("found mongod at: %q", mongopath)
-	if mongopath == "/usr/lib/juju/bin/mongod" {
+	if mongopath == "/usr/lib/juju/bin/mongod" || mongopath == "/usr/lib/juju/mongo3.2/bin/mongod" {
 		inst.WithoutV8 = true
 	}
 	server := exec.Command(mongopath, mgoargs...)
@@ -312,7 +312,7 @@ func (inst *MgoInstance) run() error {
 
 func getMongod() (string, error) {
 	// The last path is needed in tests on CentOS where PATH is being completely removed
-	paths := []string{"mongod", "/usr/lib/juju/bin/mongod", "/usr/local/bin/mongod"}
+	paths := []string{"mongod", "/usr/lib/juju/bin/mongod", "/usr/lib/juju/mongo3.2/bin/mongod", "/usr/local/bin/mongod"}
 	if path := os.Getenv("JUJU_MONGOD"); path != "" {
 		paths = append([]string{path}, paths...)
 	}

--- a/mgo.go
+++ b/mgo.go
@@ -499,6 +499,16 @@ func (s *MgoSuite) TearDownSuite(c *gc.C) {
 	mgo.SetLogger(nil)
 }
 
+// MustDial returns a new connection to the MongoDB server, and panics on
+// errors.
+func (inst *MgoInstance) MustDial() *mgo.Session {
+	s, err := mgo.DialWithInfo(inst.DialInfo())
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
 // Dial returns a new connection to the MongoDB server.
 func (inst *MgoInstance) Dial() (*mgo.Session, error) {
 	var session *mgo.Session


### PR DESCRIPTION
replicaset tests seem not to have been passing for some time, and require these changes in mgo.go:

 * Add version 3.2 to the mongod paths
 * Reinstate MustDial() function
