### PR TITLE
Mongo 3.4 uses a different string to indicate it is ready for connections

### DIFF
--- a/mgo.go
+++ b/mgo.go
@@ -43,7 +43,7 @@ var (
 	logger    = loggo.GetLogger("juju.testing")
 
 	// regular expression to match output of mongod
-	waitingForConnectionsRe = regexp.MustCompile(".*initandlisten.*waiting for connections.*")
+	waitingForConnectionsRe = regexp.MustCompile(".*waiting for connections.*")
 
 	// After version 3.2 we shouldn't use --nojournal - it makes the
 	// WiredTiger storage engine much slower.


### PR DESCRIPTION

The line is specifically:
  2017-02-22T12:51:41.107+0400 I NETWORK  [thread1] waiting for connections on port 9999

I don't know if we are ready to support all of mongo 3.4, but this allows me to run the test suite on Mac OS X when I have whatever Mongo I could install from homebrew. It seems a safe enough change.
