### PR TITLE
Prefer mongod 3.2 and improve mongod info caching

### DIFF
--- a/mgo.go
+++ b/mgo.go
@@ -317,11 +317,17 @@ func (inst *MgoInstance) run() error {
 }
 
 func getMongod() (string, error) {
-	// The last path is needed in tests on CentOS where PATH is being completely removed
-	paths := []string{"mongod", "/usr/lib/juju/bin/mongod", "/usr/lib/juju/mongo3.2/bin/mongod", "/usr/local/bin/mongod"}
+	// Prefer $JUJU_MONGOD and then newer MongoDBs.
+	var paths []string
 	if path := os.Getenv("JUJU_MONGOD"); path != "" {
-		paths = append([]string{path}, paths...)
+		paths = append(paths, path)
 	}
+	paths = append(paths,
+		"/usr/lib/juju/mongo3.2/bin/mongod",
+		"mongod",
+		"/usr/lib/juju/bin/mongod",
+		"/usr/local/bin/mongod", // Needed on CentOS where $PATH is being completely removed
+	)
 	var err error
 	var mongopath string
 	for _, path := range paths {


### PR DESCRIPTION
Previously, MongoDB 2.4 (from juju-mongodb) and the system installed
MongoDB (2.6) were preferred over MongoDB 3.2 (which is actually used
in production).

Cache the MongoDB path alongside the version. Previously there was a
small chance that the cached version would not match the mongod
version. This also avoids unnecessarily looking up the mongod path all
the time.