### PR TITLE
Add MgoInstance.SSLEnabled method

### DIFF
--- a/mgo.go
+++ b/mgo.go
@@ -113,6 +113,11 @@ func (m *MgoInstance) Port() int {
 	return m.port
 }
 
+// SSLEnabled reports whether or not SSL is enabled for the MongoDB server.
+func (m *MgoInstance) SSLEnabled() bool {
+	return m.certs != nil
+}
+
 // We specify a timeout to mgo.Dial, to prevent
 // mongod failures hanging the tests.
 const mgoDialTimeout = 60 * time.Second


### PR DESCRIPTION
Add a method to report whether an MgoInstance
has SSL enabled, so clients can decide how to
connect.