### PR TITLE
Remove deprecated --sslOnNormalPorts arg to mongod

### DIFF
--- a/mgo.go
+++ b/mgo.go
@@ -252,7 +252,7 @@ func (inst *MgoInstance) run() error {
 	}
 	if inst.certs != nil {
 		mgoargs = append(mgoargs,
-			"--sslOnNormalPorts",
+			"--sslMode requireSSL",
 			"--sslPEMKeyFile", filepath.Join(inst.dir, "server.pem"),
 			"--sslPEMKeyPassword=ignored")
 	}


### PR DESCRIPTION
--sslOnNormalPorts is deprecated past Mongo 2.6
Use the new --sslMode arg instead.