### PR TITLE
Fix typo in mongo command

### DIFF
--- a/mgo.go
+++ b/mgo.go
@@ -252,7 +252,7 @@ func (inst *MgoInstance) run() error {
 	}
 	if inst.certs != nil {
 		mgoargs = append(mgoargs,
-			"--sslMode requireSSL",
+			"--sslMode", "requireSSL",
 			"--sslPEMKeyFile", filepath.Join(inst.dir, "server.pem"),
 			"--sslPEMKeyPassword=ignored")
 	}


### PR DESCRIPTION
juju/mongo tests failed, which identified this typo