### PR TITLE
It seems to work better if we drop the capped collection.

### DIFF
--- a/mgo.go
+++ b/mgo.go
@@ -691,9 +691,7 @@ func clearNormalCollection(collection *mgo.Collection) error {
 }
 
 func clearCappedCollection(collection *mgo.Collection) error {
-	// This is a test command - relies on the enableTestCommands
-	// setting being passed to mongo at startup.
-	return collection.Database.Run(bson.D{{"emptycapped", collection.Name}}, nil)
+	return collection.DropCollection()
 }
 
 func (s *MgoSuite) SetUpTest(c *gc.C) {


### PR DESCRIPTION
This allows us to create the collection again in the next test, and
there is only 1 table that encounters this.

We'll want to time whether this has a large impact on how fast/slow the test suite is.
I feel like I'm actually missing something important, because it looks like we are calling Initialize on every SetUpTest but it isn't actually re-using the database somehow.

But with this and https://github.com/juju/juju/pull/7930 I was able to run 'go test' with Mongo 3.4