### PR TITLE
Stub check calls without order.

### DIFF
--- a/stub.go
+++ b/stub.go
@@ -5,11 +5,11 @@ package testing
 
 import (
 	"fmt"
+	"reflect"
 	"sync"
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-	"reflect"
 )
 
 // StubCall records the name of a called function and the passed args.

--- a/stub_test.go
+++ b/stub_test.go
@@ -446,3 +446,25 @@ func (s *stubSuite) TestMethodCallsUnordered(c *gc.C) {
 		FuncName: "Method2",
 	}})
 }
+
+// This case checks that in the scenario when expected calls are
+// [a,b,c,c] but the calls made are actually [a,b,b,c], we fail correctly.
+func (s *stubSuite) TestMethodCallsUnorderedDuplicateFail(c *gc.C) {
+	s.stub.MethodCall(s.stub, "Method1", 1, 2, 3)
+	s.stub.MethodCall(s.stub, "Method1", 1, 2, 3)
+	s.stub.AddCall("aFunc", "arg")
+	s.stub.MethodCall(s.stub, "Method2")
+
+	s.stub.CheckCallsUnordered(c, []testing.StubCall{{
+		FuncName: "aFunc",
+		Args:     []interface{}{"arg"},
+	}, {
+		FuncName: "Method1",
+		Args:     []interface{}{1, 2, 3},
+	}, {
+		FuncName: "Method2",
+	}, {
+		FuncName: "Method2",
+	}})
+	c.ExpectFailure("should have failed as expected calls differ from calls made")
+}

--- a/stub_test.go
+++ b/stub_test.go
@@ -430,3 +430,19 @@ func (s *stubSuite) TestCheckNoCalls(c *gc.C) {
 	c.ExpectFailure(`the "standard" Stub.CheckNoCalls call should fail here`)
 	s.stub.CheckNoCalls(c)
 }
+
+func (s *stubSuite) TestMethodCallsUnordered(c *gc.C) {
+	s.stub.MethodCall(s.stub, "Method1", 1, 2, 3)
+	s.stub.AddCall("aFunc", "arg")
+	s.stub.MethodCall(s.stub, "Method2")
+
+	s.stub.CheckCallsUnordered(c, []testing.StubCall{{
+		FuncName: "aFunc",
+		Args:     []interface{}{"arg"},
+	}, {
+		FuncName: "Method1",
+		Args:     []interface{}{1, 2, 3},
+	}, {
+		FuncName: "Method2",
+	}})
+}


### PR DESCRIPTION
All current methods on testing Stub assume that the order of calls matters.

However, there are situations where we only care about the fact that the calls where made, not in what order they were made. For example, intermittent failures in https://bugs.launchpad.net/juju/+bug/1742222 specifically occur because we expect the calls to have been made but the calls in asynchronous system can be made in any order.

This PR adds a method that allows to check that the expected calls where made, not when they were made. 