### PR TITLE
Don't try to truncate the local replicaset oplog.

### DIFF
--- a/mgo.go
+++ b/mgo.go
@@ -659,6 +659,11 @@ func clearCollections(db *mgo.Database) error {
 		if strings.HasPrefix(name, "system.") {
 			continue
 		}
+		if name == "oplog.rs" && db.Name == "local" {
+			// 3.4 prevents you from deleting your local replicaset information
+			// while part of a replica. Arguably it was never safe to do.
+			continue
+		}
 		collection := db.C(name)
 		clearFunc := clearNormalCollection
 		capped, err := isCapped(collection)


### PR DESCRIPTION
In Mongo 3.4 it now prevents you from doing this. It doesn't seem like
it would ever be a really good idea to do, as it would arguably break
your system. (if you really were part of a replicaset, you've now lost
your ability to track what changes have and haven't been applied.)
It was semi-ok in that we are resetting the database, but since the
replicaset would still potentially be running, we really don't want to
do this.

This was done for Launchpad [Bug 1749078](https://pad.lv/1749078)