### PR TITLE
Expose the version of Mongo that we are testing against.

### DIFF
--- a/mgo.go
+++ b/mgo.go
@@ -354,6 +354,11 @@ type mongodCache struct {
 	done    bool
 }
 
+func MongodVersion() (version.Number, error) {
+	_, v, err := installedMongod.Get()
+	return v, err
+}
+
 func (cache *mongodCache) Get() (string, version.Number, error) {
 	cache.Lock()
 	defer cache.Unlock()


### PR DESCRIPTION
Rather than having other code search for a 'mongod' just so we can report a version, we've already done the version check, and we can just report it. That also avoids any chance of skew, where the mongod we decide to use isn't the one we find later.
