### PR TITLE
Add the location of mongod in bionic to the list of places we look.

### DIFF
--- a/mgo.go
+++ b/mgo.go
@@ -387,6 +387,7 @@ func getMongod() (string, error) {
 		"/usr/lib/juju/mongo3.2/bin/mongod",
 		"mongod",
 		"/usr/lib/juju/bin/mongod",
+		"/usr/bin/mongod",       // bionic
 		"/usr/local/bin/mongod", // Needed on CentOS where $PATH is being completely removed
 	)
 	var err error

--- a/tcpproxy.go
+++ b/tcpproxy.go
@@ -44,7 +44,7 @@ func NewTCPProxy(c *gc.C, remoteAddr string) *TCPProxy {
 			client, err := p.listener.Accept()
 			if err != nil {
 				if !p.isClosed() {
-					c.Error("cannot accept: %v", err)
+					c.Errorf("cannot accept: %v", err)
 				}
 				return
 			}
@@ -52,7 +52,7 @@ func NewTCPProxy(c *gc.C, remoteAddr string) *TCPProxy {
 			server, err := net.Dial("tcp", remoteAddr)
 			if err != nil {
 				if !p.isClosed() {
-					c.Error("cannot dial remote address: %v", err)
+					c.Errorf("cannot dial remote address: %v", err)
 				}
 				return
 			}


### PR DESCRIPTION
If we don't have this then trying to restart the MgoServer can and does fail on bionic inside an isolation suite.