### PR TITLE
Enable Mongo with Replica Sets

### DIFF
--- a/mgo.go
+++ b/mgo.go
@@ -358,9 +358,10 @@ func mongoStorageEngine() string {
 	}
 	switch runtime.GOARCH {
 	case "amd64":
-		// On x86(_64), mmapv1 should always be available. If not
-		// overridden via the environment variable above, we use
-		// mmapv1 by default for the best performance in tests.
+                // Use 'wiredTiger' unless explicitly requested to use a
+                // different backend.  mmapv1 is generally available, but
+                // doesn't support things like server-side transactions, and
+                // also isn't our production backend.
 		return "wiredTiger"
 	}
 	return "" // use the default
@@ -663,10 +664,6 @@ func MgoDialInfo(certs *Certs, addrs ...string) *mgo.DialInfo {
 
 func clearDatabases(session *mgo.Session) error {
 	databases, err := session.DatabaseNames()
-	if err != nil && err.Error() == "EOF" {
-		session.Refresh()
-		databases, err = session.DatabaseNames()
-	}
 	if err != nil {
 		return errors.Annotate(err, "failed to list database names")
 	}

--- a/mgo_test.go
+++ b/mgo_test.go
@@ -46,10 +46,12 @@ func (s *mgoSuite) TestResetWhenUnauthorized(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	defer session.Close()
 	err = session.DB("admin").AddUser("admin", "foo", false)
+	c.Logf("Adding user resulted in: %v", err)
 	if err != nil && err.Error() != "need to login" {
 		c.Assert(err, gc.IsNil)
 	}
 	// The test will fail if the reset does not succeed
+	testing.MgoServer.Reset()
 }
 
 func (s *mgoSuite) TestStartAndClean(c *gc.C) {
@@ -94,5 +96,5 @@ func (s *mgoSuite) TestNewProxiedSession(c *gc.C) {
 	session.CloseConns()
 	err = session.Ping()
 	// There's no consistent error in this case.
-	c.Assert(err, gc.Not(gc.Equals), nil)
+	c.Assert(err, gc.NotNil)
 }


### PR DESCRIPTION
This adds a boolean that lets us specify that Mongod should be started with a replSet enabled.
We have historically disabled this, because it adds a fair bit of time to Mongod startup (running this test suite takes 3s vs 5s).
However, the test suite also was *failing* when it was enabled, because we were deleting collections that Mongo needs to have to operate correctly. (The surprising one was local.replicaset.minvalid.)

Digging into what collections are in 'config', and 'local', we really don't want to be deleting anything in there. So this skips those collections explicitly.

I ran the test suite with Mongo 3.6 and Mongo 4.0.5 on Bionic and used this patch:
```
diff --git a/mgo.go b/mgo.go
index 296bb52..14eaeaa 100644
--- a/mgo.go
+++ b/mgo.go
@@ -251,6 +251,7 @@ func (inst *MgoInstance) run() error {
                        "--keyFile", filepath.Join(inst.dir, "keyfile"),
                )
        }
+       inst.EnableReplicaSet = true
        if inst.EnableReplicaSet {
                mgoargs = append(mgoargs,"--replSet=juju")
        }
@@ -265,6 +266,7 @@ func (inst *MgoInstance) run() error {
        if err != nil {
                return err
        }
+       fmt.Fprintf(os.Stderr, "using mongod at: %q (version=%s)\n", mongopath, version)
        logger.Debugf("using mongod at: %q (version=%s)", mongopath, version)

        if version.Compare(useJournalMongoVersion) == -1 {
```

to make sure I was using the right versions of mongo, and trying it both with and without replica set enabled.

To support server-side-transactions, we will need to enable replicaset. This just makes it possible for us to chose whether we want to be testing that.
