### PR TITLE
Add support for finding the juju-db snap when looking for mongod

### DIFF
--- a/mgo.go
+++ b/mgo.go
@@ -384,6 +384,7 @@ func getMongod() (string, error) {
 		paths = append(paths, path)
 	}
 	paths = append(paths,
+		"/snap/juju-db/current/bin/monogod",
 		"/usr/lib/juju/mongo3.2/bin/mongod",
 		"mongod",
 		"/usr/lib/juju/bin/mongod",


### PR DESCRIPTION
This commit adds `/snap/juju-db/current/bin/monogod` to the list of searched paths when looking for a `mongod` instance.