### PR TITLE
Allow testing of DoRequest against status code

### DIFF
--- a/httptesting/http.go
+++ b/httptesting/http.go
@@ -165,6 +165,10 @@ type DoRequestParams struct {
 	// nil.
 	ExpectError string
 
+	// ExpectStatus holds the expected HTTP status code.
+	// If unset or zero, then no check is performed.
+	ExpectStatus int
+
 	// Method holds the HTTP method to use for the call.
 	// GET is assumed if this is empty.
 	Method string
@@ -276,6 +280,9 @@ func Do(c *gc.C, p DoRequestParams) *http.Response {
 		return nil
 	}
 	c.Assert(err, jc.ErrorIsNil)
+	if p.ExpectStatus != 0 {
+		c.Assert(resp.StatusCode, gc.Equals, p.ExpectStatus)
+	}
 	return resp
 }
 


### PR DESCRIPTION
The following changes are required so we can test against the
status code along with the error of a http request.

Changing this allows us to work with go-1.12 where the changes to
the http(s) server when calling https using http now returns a 400
status code instead of malformed garbage.

See: https://go-review.googlesource.com/c/go/+/98447/