### PR TITLE
Use ephemeralForTest storage engine for tests

### DIFF
--- a/mgo.go
+++ b/mgo.go
@@ -424,20 +424,7 @@ func mongoStorageEngine(replicaset bool) string {
 	if storageEngine != "" {
 		return storageEngine
 	}
-	switch runtime.GOARCH {
-	case "amd64":
-		if replicaset {
-			// Use 'wiredTiger' unless explicitly requested to use a
-			// different backend.  mmapv1 is generally available, but
-			// doesn't support things like server-side transactions, and
-			// also isn't our production backend.
-			return "wiredTiger"
-		} else {
-			// We use mmapv1 in the test suite as it can be 3-4x faster in many tests.
-			return "mmapv1"
-		}
-	}
-	return "" // use the default
+	return "ephemeralForTest"
 }
 
 // mongodCache looks up mongod path and version and caches the result.


### PR DESCRIPTION
The `ephemeralForTest` storage engine works on mongo 3.2 onwards.
A simple run of a subset of juju state tests showed 300% speed improvement

Results were consistent over a few runs.

```
export JUJU_MONGO_STORAGE_ENGINE=wiredTiger
$ time go test -go.check application
...
OK: 43 passed
PASS
ok      github.com/juju/juju/state      29.480s

real    0m35.341s
user    0m37.669s
sys     0m8.110s

export JUJU_MONGO_STORAGE_ENGINE=ephemeralForTest
$ time go test -go.check application
...
OK: 43 passed
PASS
ok      github.com/juju/juju/state      7.907s

real    0m22.940s
user    1m10.539s
sys     0m7.804s
```
