### PR TITLE
EnableReplicaSet on MgoServer for tests using transactions on MgoSuite

### DIFF
--- a/mgo.go
+++ b/mgo.go
@@ -42,7 +42,9 @@ import (
 
 var (
 	// MgoServer is a shared mongo server used by tests.
-	MgoServer = &MgoInstance{}
+	MgoServer = &MgoInstance{
+		EnableReplicaSet: true,
+	}
 	logger    = loggo.GetLogger("juju.testing")
 
 	// regular expression to match output of mongod


### PR DESCRIPTION
Some of the tests on https://github.com/juju/juju/pull/14087 that are using the `MgoSuite` (through `StateSuite`) are getting `transaction aborted` from mongo, where the underlying error is:

`[LOG] 0:04.415 ERROR juju.txn error while aborting: Transaction numbers are only allowed on a replica set member or mongos`

e.g. `juju/worker/raft/raftforwarder/manifold_test.go`

Setting `EnableReplicaSet: true` fixes the tests.