### PR TITLE
Added time checkers After, Before and Almost

### DIFF
--- a/checkers/time.go
+++ b/checkers/time.go
@@ -1,0 +1,57 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package checkers
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+	"time"
+
+	gc "gopkg.in/check.v1"
+)
+
+type timeCompareChecker struct {
+	*gc.CheckerInfo
+	compareFunc func(time.Time, time.Time) bool
+}
+
+// After checks whether the obtained time.Time is After the want time.Time.
+var After gc.Checker = &timeCompareChecker{
+	CheckerInfo: &gc.CheckerInfo{Name: "After", Params: []string{"obtained", "want"}},
+	compareFunc: func(t1, t2 time.Time) bool {
+		return t1.After(t2)
+	},
+}
+
+// Before checks whether the obtained time.Time is Before the want time.Time.
+var Before gc.Checker = &timeCompareChecker{
+	CheckerInfo: &gc.CheckerInfo{Name: "Before", Params: []string{"obtained", "want"}},
+	compareFunc: func(t1, t2 time.Time) bool {
+		return t1.Before(t2)
+	},
+}
+
+// Almost checks whether the obtained time.Time is within 1s of the want time.Time.
+var Almost gc.Checker = &timeCompareChecker{
+	CheckerInfo: &gc.CheckerInfo{Name: "Almost", Params: []string{"obtained", "want"}},
+	compareFunc: func(t1, t2 time.Time) bool {
+		return math.Abs(t1.Sub(t2).Seconds()) <= 1.0
+	},
+}
+
+func (checker *timeCompareChecker) Check(params []interface{}, names []string) (result bool, error string) {
+	if len(params) != 2 {
+		return false, fmt.Sprintf("expected 2 parameters, received %d", len(params))
+	}
+	t1, ok := params[0].(time.Time)
+	if !ok {
+		return false, fmt.Sprintf("obtained param: expected type time.Time, received type %s", reflect.ValueOf(params[0]).Type())
+	}
+	t2, ok := params[1].(time.Time)
+	if !ok {
+		return false, fmt.Sprintf("want param: expected type time.Time, received type %s", reflect.ValueOf(params[1]).Type())
+	}
+	return checker.compareFunc(t1, t2), ""
+}

--- a/checkers/time_test.go
+++ b/checkers/time_test.go
@@ -1,0 +1,71 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package checkers_test
+
+import (
+	"time"
+
+	gc "gopkg.in/check.v1"
+
+	jc "github.com/juju/testing/checkers"
+)
+
+type TimeSuite struct{}
+
+var _ = gc.Suite(&TimeSuite{})
+
+func (s *TimeSuite) TestBefore(c *gc.C) {
+	now := time.Now()
+	c.Assert(now, jc.Before, now.Add(time.Second))
+	c.Assert(now, gc.Not(jc.Before), now.Add(-time.Second))
+
+	result, msg := jc.Before.Check([]interface{}{time.Time{}}, nil)
+	c.Assert(result, gc.Equals, false)
+	c.Check(msg, gc.Equals, `expected 2 parameters, received 1`)
+
+	result, msg = jc.Before.Check([]interface{}{42, time.Time{}}, nil)
+	c.Assert(result, gc.Equals, false)
+	c.Assert(msg, gc.Equals, `obtained param: expected type time.Time, received type int`)
+
+	result, msg = jc.Before.Check([]interface{}{time.Time{}, "wow"}, nil)
+	c.Assert(result, gc.Equals, false)
+	c.Assert(msg, gc.Matches, `want param: expected type time.Time, received type string`)
+}
+
+func (s *TimeSuite) TestAfter(c *gc.C) {
+	now := time.Now()
+	c.Assert(now, gc.Not(jc.After), now.Add(time.Second))
+	c.Assert(now, jc.After, now.Add(-time.Second))
+
+	result, msg := jc.After.Check([]interface{}{time.Time{}}, nil)
+	c.Assert(result, gc.Equals, false)
+	c.Check(msg, gc.Equals, `expected 2 parameters, received 1`)
+
+	result, msg = jc.After.Check([]interface{}{42, time.Time{}}, nil)
+	c.Assert(result, gc.Equals, false)
+	c.Assert(msg, gc.Equals, `obtained param: expected type time.Time, received type int`)
+
+	result, msg = jc.After.Check([]interface{}{time.Time{}, "wow"}, nil)
+	c.Assert(result, gc.Equals, false)
+	c.Assert(msg, gc.Matches, `want param: expected type time.Time, received type string`)
+}
+
+func (s *TimeSuite) TestAlmost(c *gc.C) {
+	now := time.Now()
+	c.Assert(now, gc.Not(jc.Almost), now.Add(1001*time.Millisecond))
+	c.Assert(now, jc.Almost, now.Add(-time.Second))
+	c.Assert(now, jc.Almost, now.Add(time.Second))
+
+	result, msg := jc.Almost.Check([]interface{}{time.Time{}}, nil)
+	c.Assert(result, gc.Equals, false)
+	c.Check(msg, gc.Equals, `expected 2 parameters, received 1`)
+
+	result, msg = jc.Almost.Check([]interface{}{42, time.Time{}}, nil)
+	c.Assert(result, gc.Equals, false)
+	c.Assert(msg, gc.Equals, `obtained param: expected type time.Time, received type int`)
+
+	result, msg = jc.Almost.Check([]interface{}{time.Time{}, "wow"}, nil)
+	c.Assert(result, gc.Equals, false)
+	c.Assert(msg, gc.Matches, `want param: expected type time.Time, received type string`)
+}


### PR DESCRIPTION
Added time checkers:
- After: obtained time is after the expected time.
- Before: obtained time is before the expected time.
- Almost: obtained time is at most 1s before or after the expected time.